### PR TITLE
Better tests for finalsize

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,5 @@ Config/testthat/edition: 3
 License: MIT + file LICENSE
 Remotes:
     epiforecasts/socialmixr
-Imports: 
-    assertthat,
+Imports:
     checkmate

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -44,21 +44,25 @@ final_size <- function(r0 = 2, contact_matrix, demography_vector,
                        prop_initial_infected = 0.001,
                        prop_suscep = NULL) {
 
-  # Check inputs
+  # Check prop_suscep length
   if (is.null(prop_suscep)) {
-    prop_suscep <- rep(1, length(demography_vector))
+    prop_suscep <- 1.0
   } else {
     checkmate::assert_numeric(
       prop_suscep,
       lower = 0.0, upper = 1.0, finite = TRUE
     )
-    if (length(prop_suscep) == 1L) {
-      prop_suscep <- rep(prop_suscep, length(demography_vector))
-    } else if (length(unique(prop_suscep)) > 1L) {
-      message("using different susceptibilities for each age group")
+    if (length(prop_suscep) > 1L) {
+      assertthat::assert_that(
+        length(demography_vector) == length(prop_suscep),
+        msg = "demography vector needs to be same size as susceptibility vector"
+      )
+
+      if (length(unique(prop_suscep)) > 1L) {
+        message("using different susceptibilities for each age group")
+      }
     }
   }
-
   checkmate::assert_number(r0, lower = 1.0, finite = TRUE)
   checkmate::assert_numeric(demography_vector, lower = 0.0)
   checkmate::assert_matrix(contact_matrix)
@@ -67,10 +71,6 @@ final_size <- function(r0 = 2, contact_matrix, demography_vector,
   assertthat::assert_that(
     nrow(contact_matrix) == length(demography_vector),
     msg = "demography vector needs to be same size as contact matrix"
-  )
-  assertthat::assert_that(
-    length(demography_vector) == length(prop_suscep),
-    msg = "demography vector needs to be same size as susceptibility vector"
   )
 
   if (length(prop_initial_infected) > 1) {

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -59,10 +59,10 @@ final_size <- function(r0 = 2, contact_matrix, demography_vector,
     }
   }
 
-  checkmate::assert_number(r0, lower = 0.0, finite = TRUE)
-  checkmate::assert_vector(demography_vector)
+  checkmate::assert_number(r0, lower = 1.0, finite = TRUE)
+  checkmate::assert_numeric(demography_vector, lower = 0.0)
   checkmate::assert_matrix(contact_matrix)
-  checkmate::assert_numeric(prop_initial_infected)
+  checkmate::assert_numeric(prop_initial_infected, lower = 0.0, upper = 1.0)
 
   assertthat::assert_that(
     nrow(contact_matrix) == length(demography_vector),

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -47,7 +47,17 @@ final_size <- function(r0 = 2, contact_matrix, demography_vector,
   # Check inputs
   if (is.null(prop_suscep)) {
     prop_suscep <- rep(1, length(demography_vector))
-  } # Assume fully susceptible if no entry
+  } else {
+    checkmate::assert_numeric(
+      prop_suscep,
+      lower = 0.0, upper = 1.0, finite = TRUE
+    )
+    if (length(prop_suscep) == 1L) {
+      prop_suscep <- rep(prop_suscep, length(demography_vector))
+    } else if (length(unique(prop_suscep)) > 1L) {
+      message("using different susceptibilities for each age group")
+    }
+  }
 
   checkmate::assert_number(r0, lower = 0.0, finite = TRUE)
   checkmate::assert_vector(demography_vector)

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -53,9 +53,9 @@ final_size <- function(r0 = 2, contact_matrix, demography_vector,
       lower = 0.0, upper = 1.0, finite = TRUE
     )
     if (length(prop_suscep) > 1L) {
-      assertthat::assert_that(
-        length(demography_vector) == length(prop_suscep),
-        msg = "demography vector needs to be same size as susceptibility vector"
+      stopifnot(
+        "demography vector needs to be same size as susceptibility vector" =
+          length(demography_vector) == length(prop_suscep)
       )
 
       if (length(unique(prop_suscep)) > 1L) {
@@ -68,16 +68,16 @@ final_size <- function(r0 = 2, contact_matrix, demography_vector,
   checkmate::assert_matrix(contact_matrix)
   checkmate::assert_numeric(prop_initial_infected, lower = 0.0, upper = 1.0)
 
-  assertthat::assert_that(
-    nrow(contact_matrix) == length(demography_vector),
-    msg = "demography vector needs to be same size as contact matrix"
+  stopifnot(
+    "demography vector needs to be same size as contact matrix" =
+      nrow(contact_matrix) == length(demography_vector)
   )
 
   if (length(prop_initial_infected) > 1) {
-    assertthat::assert_that(
-      length(prop_initial_infected) == length(demography_vector),
-      msg = "vector of prop_initial_infected needs to be same size
-      as demography vector"
+    stopifnot(
+      "vector of prop_initial_infected needs to be same size
+      as demography vector" =
+        length(prop_initial_infected) == length(demography_vector)
     )
     message(
       "using different prop_initial_infected for each age group"

--- a/tests/testthat/test-test_basic_finalsize.R
+++ b/tests/testthat/test-test_basic_finalsize.R
@@ -24,6 +24,49 @@ test_that("Check basic final size calculation works", {
   )
 })
 
+test_that("Check final size r0 inputs", {
+  c_matrix <- matrix(0.5, 2, 2)
+  d_vector <- rep(0.5, 2)
+  p_suscep <- c(1)
+  p_initial_infections <- 0.0015
+
+  # expect error for negative r0
+  testthat::expect_error(
+    final_size(
+      r0 = -1.0,
+      contact_matrix = c_matrix,
+      demography_vector = d_vector,
+      prop_initial_infected = p_initial_infections,
+      prop_suscep = p_suscep
+    ),
+    regexp = "(Element 1 is not >= 1)"
+  )
+
+  # expect error for r0 < 1
+  testthat::expect_error(
+    final_size(
+      r0 = 0.99,
+      contact_matrix = c_matrix,
+      demography_vector = d_vector,
+      prop_initial_infected = p_initial_infections,
+      prop_suscep = p_suscep
+    ),
+    regexp = "(Element 1 is not >= 1)"
+  )
+
+  # expect error for infinite r0
+  testthat::expect_error(
+    final_size(
+      r0 = Inf,
+      contact_matrix = c_matrix,
+      demography_vector = d_vector,
+      prop_initial_infected = p_initial_infections,
+      prop_suscep = p_suscep
+    ),
+    regexp = "(Must be finite)"
+  )
+})
+
 test_that("Check failure for unequal contact matrix and demography", {
   polymod <- socialmixr::polymod
   contact_data <- socialmixr::contact_matrix(

--- a/tests/testthat/test-test_basic_finalsize.R
+++ b/tests/testthat/test-test_basic_finalsize.R
@@ -76,7 +76,7 @@ test_that("Check failure for unequal contact matrix and demography", {
   )
   c_matrix <- t(contact_data$matrix)
   d_vector <- c(0.5, 0.5) # manually created
-  p_suscep <- c(1, 1, 1)
+  p_suscep <- 1.0
   p_initial_infections <- c(0.1, 0.5, 0.5)
 
   testthat::expect_error(

--- a/tests/testthat/test-test_finalsize_calculations.R
+++ b/tests/testthat/test-test_finalsize_calculations.R
@@ -1,0 +1,38 @@
+test_that("Final size calculations are correct", {
+  polymod <- socialmixr::polymod
+  contact_data <- socialmixr::contact_matrix(
+    polymod,
+    countries = "United Kingdom",
+    age.limits = c(0, 20, 40)
+  )
+  c_matrix <- t(contact_data$matrix)
+  d_vector <- contact_data$participants$proportion
+  p_initial_infections <- 0.002
+  p_suscep <- c(1, 1, 1)
+
+  # r0 greater than 1
+  vector_r0 <- seq(1.01, 3.0, 0.5)
+
+  # check that final sizes > initial sizes
+  invisible(
+    lapply(
+      vector_r0, function(r0) {
+        fs <- final_size(
+          r0 = r0,
+          contact_matrix = c_matrix,
+          demography_vector = d_vector,
+          prop_initial_infected = p_initial_infections,
+          prop_suscep = p_suscep
+        )
+
+        testthat::expect_true(
+          all(fs >= p_initial_infections)
+        )
+
+        testthat::expect_true(
+          all(fs <= 1.0)
+        )
+      }
+    )
+  )
+})

--- a/tests/testthat/test-test_finalsize_calculations.R
+++ b/tests/testthat/test-test_finalsize_calculations.R
@@ -135,3 +135,26 @@ test_that("Check final size when one age group is not susceptible", {
   testthat::expect_equal(max_pi$convergence, 0)
   testthat::expect_lte(pi, max_pi$par)
 })
+
+test_that("Check that isolated age groups are not infected", {
+  c_matrix <- matrix(0.2, 3, 3)
+
+  isolated_grp <- 3L
+  c_matrix[, isolated_grp] <- 0.0
+  c_matrix[isolated_grp, ] <- 0.0
+
+  d_vector <- c(0.2, 0.5, 0.2)
+  p_suscep <- 1.0
+  r0_value <- 3.0
+
+  epi_final_size <- final_size(
+    r0 = r0_value,
+    contact_matrix = c_matrix,
+    demography_vector = d_vector,
+    prop_suscep = p_suscep
+  )
+
+  testthat::expect_identical(
+    epi_final_size[isolated_grp], 0.0
+  )
+})

--- a/tests/testthat/test-test_finalsize_calculations.R
+++ b/tests/testthat/test-test_finalsize_calculations.R
@@ -1,3 +1,17 @@
+# Calculates the upper limit of final size given the r0
+# The upper limit is given by a well mixed population
+upper_limit <- function(r0) {
+  f <- function(par) {
+    abs(1 - exp(-r0 * par[1]) - par[1])
+  }
+  opt <- optim(
+    par = c(0.5), fn = f,
+    lower = c(0), upper = c(1),
+    method = "Brent"
+  )
+  opt
+}
+
 test_that("Final size calculations are correct", {
   polymod <- socialmixr::polymod
   contact_data <- socialmixr::contact_matrix(


### PR DESCRIPTION
Adding better tests for `finalsize` and `final_size`.
- Fixes #29 by setting lower limit for `r0` at 1.0. Values below this result in a final epidemic size of 0.0.
- Fixes #30 by checking that epidemic final sizes are below `prop_initial_infected` and 1.0 _in each age group_
- Adds tests by @BlackEdder taken from #26 for plausible epidemic sizes
- Adds the helper function `upper_limit` from @BlackEdder from #26 
- Fixes #31 by allow `prop_suscep` to be a single population wide value