### PR TITLE
Better tests for final size by susceptibility groups

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -43,12 +43,12 @@ RcppExport SEXP _finalsize_final_size_cpp(SEXP r0SEXP, SEXP contact_matrixSEXP,
   END_RCPP
 }
 // final_size_grps_cpp
-Eigen::VectorXd final_size_grps_cpp(const Eigen::MatrixXd& contact_matrix,
-                                    const Eigen::VectorXd& demography_vector,
-                                    const Eigen::MatrixXd& p_susceptibility,
-                                    const Eigen::MatrixXd& susceptibility,
-                                    const int iterations, const bool adapt_step,
-                                    const double tolerance);
+Eigen::ArrayXd final_size_grps_cpp(const Eigen::MatrixXd& contact_matrix,
+                                   const Eigen::VectorXd& demography_vector,
+                                   const Eigen::MatrixXd& p_susceptibility,
+                                   const Eigen::MatrixXd& susceptibility,
+                                   const int iterations, const bool adapt_step,
+                                   const double tolerance);
 RcppExport SEXP _finalsize_final_size_grps_cpp(
     SEXP contact_matrixSEXP, SEXP demography_vectorSEXP,
     SEXP p_susceptibilitySEXP, SEXP susceptibilitySEXP, SEXP iterationsSEXP,

--- a/src/finalsize_risk_grps.cpp
+++ b/src/finalsize_risk_grps.cpp
@@ -24,7 +24,7 @@
 //' @keywords epidemic model
 //' @export
 // [[Rcpp::export]]
-Eigen::VectorXd final_size_grps_cpp(const Eigen::MatrixXd &contact_matrix,
+Eigen::ArrayXd final_size_grps_cpp(const Eigen::MatrixXd &contact_matrix,
                                    const Eigen::VectorXd &demography_vector,
                                    const Eigen::MatrixXd &p_susceptibility,
                                    const Eigen::MatrixXd &susceptibility,
@@ -50,15 +50,14 @@ Eigen::VectorXd final_size_grps_cpp(const Eigen::MatrixXd &contact_matrix,
         "same dims\n");
   }
   // check that p_susceptibility rowwise sums are approx 1.0 - ideally sum to 1
-  for (size_t i = 0; i < p_susceptibility.rows(); i++)
-  {
-    if(std::abs(p_susceptibility.row(i).sum() - 1.0) > 1e-6 ) {
-      Rcpp::stop(
-        "Error: p_susceptibility matrix rows must sum to 1.0"
-      );
+  for (size_t i = 0; i < p_susceptibility.rows(); i++) {
+    if (std::abs(p_susceptibility.row(i).sum() - 1.0) > 1e-6) {
+      Rcpp::stop("Error: p_susceptibility matrix rows must sum to 1.0");
     }
-  }  
+  }
 
-  return (solve_final_size_by_susceptibility(contact_matrix, demography_vector,
-                                            p_susceptibility, susceptibility).rowwise().sum());
+  return solve_final_size_by_susceptibility(contact_matrix, demography_vector,
+                                            p_susceptibility, susceptibility)
+      .rowwise()
+      .sum();
 }

--- a/src/test-finalsize_funs.cpp
+++ b/src/test-finalsize_funs.cpp
@@ -117,6 +117,44 @@ context("Newton solver works for single risk group") {
   }
 }
 
+/// check Newton solver returns a final size > 0 and < 1 for ONE risk grp
+context("Newton solver works for single risk group, r0 = 2") {
+
+  double r0 = 2.0;
+  // make some function arguments
+  Eigen::MatrixXd contact_matrix(2, 2);
+  contact_matrix << 1.0, 0.5, 0.5, 1.0;
+  Eigen::VectorXd demography_vector(2);
+  demography_vector << 1.0, 1.0;
+
+  // make p_susceptibility with one (1) risk group
+  Eigen::MatrixXd p_susceptibility(2, 1);  // n rows per demo grp, 2 col risk
+  p_susceptibility << 0.25, 0.75;
+
+  Eigen::MatrixXd susceptibility = p_susceptibility;
+  susceptibility.fill(1.0);  // all groups have same susceptibility?
+
+  epi_spread_data tmp_data = epi_spread(contact_matrix, demography_vector,
+                                        p_susceptibility, susceptibility);
+
+  Eigen::ArrayXd final_size_temp = solve_final_size_newton(
+      r0 * contact_matrix, demography_vector, p_susceptibility, susceptibility);
+
+  test_that("Fn solve_final_size_newton returns same size as demography, r0 = 2") {
+    CATCH_CHECK(final_size_temp.size() == demography_vector.size());
+  }
+  test_that("Fn solve_final_size_newton values LTE 1.0, r0 = 2") {
+    for (size_t i = 0; i < final_size_temp.size(); i++) {
+      CATCH_CHECK(final_size_temp[i] <= 1.0);
+    }
+  }
+  test_that("Fn solve_final_size_newton values GT 0, r0 = 2") {
+    for (size_t i = 0; i < final_size_temp.size(); i++) {
+      CATCH_CHECK(final_size_temp[i] > 0.0);
+    }
+  }
+}
+
 /// check Newton solver returns a final size > 0 and < 1 for MULT risk grps
 context("Newton solver works for multiple risk groups") {
   // make some function arguments

--- a/src/test-finalsize_funs.cpp
+++ b/src/test-finalsize_funs.cpp
@@ -153,7 +153,6 @@ context("Newton solver works for multiple risk groups") {
   }
 }
 
-
 /// check Newton solver returns a final size > 0 and < 1 for identical contacts
 context("Newton solver works for identical contact matrix") {
   // make some function arguments
@@ -165,6 +164,42 @@ context("Newton solver works for identical contact matrix") {
   // make p_susceptibility with one (1) risk group
   Eigen::MatrixXd p_susceptibility(2, 2);  // n rows per demo grp, 2 col risk
   p_susceptibility << 0.25, 0.75, 0.25, 0.75;
+
+  Eigen::MatrixXd susceptibility = p_susceptibility;
+  susceptibility.fill(1.0);  // all groups have same susceptibility?
+
+  epi_spread_data tmp_data = epi_spread(contact_matrix, demography_vector,
+                                        p_susceptibility, susceptibility);
+
+  Eigen::ArrayXd final_size_temp = solve_final_size_newton(
+      contact_matrix, demography_vector, p_susceptibility, susceptibility);
+
+  test_that("Fn solve_final_size_newton returns same size as demography") {
+    CATCH_CHECK(final_size_temp.size() == demography_vector.size());
+  }
+  test_that("Fn solve_final_size_newton values LTE 1.0") {
+    for (size_t i = 0; i < final_size_temp.size(); i++) {
+      CATCH_CHECK(final_size_temp[i] <= 1.0);
+    }
+  }
+  test_that("Fn solve_final_size_newton values GT 0") {
+    for (size_t i = 0; i < final_size_temp.size(); i++) {
+      CATCH_CHECK(final_size_temp[i] > 0.0);
+    }
+  }
+}
+
+/// check Newton solver for identical contact matrix with single risk grp
+context("Newton solver works for identical contact matrix with single p_susc") {
+  // make some function arguments
+  Eigen::MatrixXd contact_matrix(2, 2);
+  contact_matrix.fill(0.5);
+  Eigen::VectorXd demography_vector(2);
+  demography_vector << 1.0, 1.0;
+
+  // make p_susceptibility with one (1) risk group
+  Eigen::MatrixXd p_susceptibility(2, 1);  // n rows per demo grp, 2 col risk
+  p_susceptibility << 1.0, 1.0;
 
   Eigen::MatrixXd susceptibility = p_susceptibility;
   susceptibility.fill(1.0);  // all groups have same susceptibility?
@@ -218,8 +253,7 @@ context("Solving by susceptibility groups works") {
 
   test_that("Fn solve_by_susc_grps values LTE 1.0") {
     for (size_t i = 0; i < final_size.size(); i++) {
-      for (size_t j = 0; j < final_size.cols(); j++)
-      {
+      for (size_t j = 0; j < final_size.cols(); j++) {
         CATCH_CHECK(final_size.coeff(i, j) <= 1.0);
       }
     }

--- a/src/test-finalsize_grps.cpp
+++ b/src/test-finalsize_grps.cpp
@@ -1,0 +1,94 @@
+/*
+ * This file uses the Catch unit testing library, alongside
+ * testthat's simple bindings, to test a C++ function.
+ *
+ * For your own packages, ensure that your test files are
+ * placed within the `src/` folder, and that you include
+ * `LinkingTo: testthat` within your DESCRIPTION file.
+ */
+
+// All test files should include the <testthat.h>
+// header file.
+#include <Rcpp.h>
+#include <RcppEigen.h>
+#include <testthat.h>
+
+#include "finalsize.h"
+
+/// some example data
+// These were generated using:
+// cm_lst <- contactsr::load_polymod_data(age_limits=c(15,30,45,60,75))
+// contactsr::symmetric_matrix(cm_lst)
+// taken from
+// https://gitlab.com/epidemics-r/code_snippets/-/blob/feature/newton_solver/tests/catch_final_size.cpp
+auto example_contact_matrix() {
+  Eigen::Matrix<double, 6, 6> cm;
+  cm << 5.329620e-08, 1.321156e-08, 1.832293e-08, 7.743492e-09, 5.888440e-09,
+      2.267918e-09, 1.321156e-08, 4.662496e-08, 1.574182e-08, 1.510582e-08,
+      7.943038e-09, 3.324235e-09, 1.832293e-08, 1.574182e-08, 2.331416e-08,
+      1.586565e-08, 1.146566e-08, 5.993247e-09, 7.743492e-09, 1.510582e-08,
+      1.586565e-08, 2.038011e-08, 1.221124e-08, 9.049331e-09, 5.888440e-09,
+      7.943038e-09, 1.146566e-08, 1.221124e-08, 1.545822e-08, 8.106812e-09,
+      2.267918e-09, 3.324235e-09, 5.993247e-09, 9.049331e-09, 8.106812e-09,
+      1.572736e-08;
+  return cm;
+}
+
+auto example_demography() {
+  Eigen::Array<double, 6, 1> demo;
+  demo << 10831795, 11612456, 13511496, 11499398, 8167102, 4587765;
+  return demo;
+}
+
+/// check that solving by risk groups returns the correct answer
+context("Correct solution to final size") {
+  const double r0 = 1.3;
+  Eigen::MatrixXd contact_matrix(2, 2);
+  contact_matrix.fill(r0 / 200.0);
+  Eigen::ArrayXd demography_vector(2);
+  demography_vector.fill(100.0);
+
+  Eigen::ArrayXd p_susceptibility(2);
+  p_susceptibility.fill(1);
+
+  Eigen::ArrayXd susceptibility(2);
+  susceptibility.fill(1);
+
+  Eigen::MatrixXd pi = solve_final_size_by_susceptibility(
+      contact_matrix, demography_vector, p_susceptibility, susceptibility);
+
+  Eigen::ArrayXd pi_2 = pi.rowwise().sum();
+  test_that("Correct solutions to final size simple case") {
+    CATCH_CHECK(pi_2(0) > 0.0);
+    CATCH_CHECK(pi_2(0) == pi_2(1));
+    CATCH_CHECK(Approx(pi_2(0)) == 1 - exp(-r0 * pi_2(0)));
+  }
+}
+
+/// check that final size by groups cpp for polymod matrix
+context("Correct solutions for Polymod matrix") {
+  double r0 = 1.3;
+  auto lambda = example_contact_matrix();
+  auto demography = example_demography();
+
+  Eigen::ArrayXd psusc(lambda.rows());
+  psusc.fill(1);
+
+  Eigen::ArrayXd susc(lambda.rows());
+  susc.fill(1);
+
+  Eigen::VectorXd pi =
+      solve_final_size_by_susceptibility(r0 * lambda, demography, psusc, susc);
+
+  test_that("Correct solutions for Polymod matrix") {
+    for (size_t i = 0; i < pi.size(); i++) {
+      CATCH_CHECK(pi(i) > 0.0);
+    }
+
+    CATCH_CHECK(pi(5) < pi(0));
+
+    double ratio = (pi.array() * demography).sum() / demography.sum();
+    CATCH_CHECK(ratio > 0.3);
+    CATCH_CHECK(ratio < 0.45);
+  }
+}

--- a/tests/testthat/test-finalsize_by_group.R
+++ b/tests/testthat/test-finalsize_by_group.R
@@ -1,4 +1,38 @@
 test_that("Check final size calculation is correct in simple case", {
+  r0 <- 1.3
+  contact_matrix <- matrix(r0 / 200, 2, 2)
+  demography_vector <- c(100, 100)
+  p_susceptibility <- matrix(1, 2, 1)
+  susceptibility <- p_susceptibility
+
+  epi_outcome <- final_size_grps_cpp(
+    contact_matrix = contact_matrix,
+    demography_vector = demography_vector,
+    p_susceptibility = p_susceptibility,
+    susceptibility = susceptibility
+  )
+
+  testthat::expect_vector(
+    epi_outcome,
+    ptype = numeric()
+  )
+  testthat::expect_false(
+    any(is.nan(epi_outcome))
+  )
+  testthat::expect_false(
+    any(is.infinite(epi_outcome))
+  )
+  testthat::expect_true(
+    all(epi_outcome > 0.0)
+  )
+
+  epi_outcome_known <- 1 - exp(-r0 * epi_outcome)
+
+  testthat::expect_equal(
+    epi_outcome, epi_outcome_known
+  )
+})
+
   r0 <- 2
   contact_matrix <- matrix(r0 / 200.0, 2, 2)
   demography_vector <- rep(100.0, 2) |> as.matrix()

--- a/tests/testthat/test-finalsize_by_group.R
+++ b/tests/testthat/test-finalsize_by_group.R
@@ -69,18 +69,18 @@ test_that("Check final size calculation simple case r0 = 2", {
 })
 
 test_that("Check final size by groups works with multiple risk groups", {
-  r0 = 2.0
-  contact_matrix = matrix(c(1, 0.5, 0.5, 1), 2, 2)
-  demography_vector = rep(1, 2)
-  p_susceptibility = rbind(
+  r0 <- 2.0
+  contact_matrix <- matrix(c(1, 0.5, 0.5, 1), 2, 2)
+  demography_vector <- rep(1, 2)
+  p_susceptibility <- rbind(
     c(0.25, 0.75),
     c(0.25, 0.75)
-)
-  susceptibility = matrix(1, 2, 2)
-  
+  )
+  susceptibility <- matrix(1, 2, 2)
+
   # scale contact matrix and demography vector
-  demography_vector = demography_vector / sum(demography_vector)
-  
+  demography_vector <- demography_vector / sum(demography_vector)
+
   epi_outcome <- final_size_grps_cpp(
     contact_matrix = r0 * contact_matrix,
     demography_vector = demography_vector,
@@ -88,7 +88,8 @@ test_that("Check final size by groups works with multiple risk groups", {
     susceptibility = susceptibility
   )
   testthat::expect_vector(
-    epi_outcome, ptype = numeric()
+    epi_outcome,
+    ptype = numeric()
   )
   testthat::expect_false(
     any(is.nan(epi_outcome))
@@ -105,29 +106,27 @@ test_that("Check final size by groups works with multiple risk groups", {
 })
 
 test_that("Check demo groups with higher suscept. have higher final size", {
-  r0 = 2.0
-  contact_matrix = matrix(c(1, 0.5, 0.5, 1), 2, 2)
-  demography_vector = rep(1, 2)
-  p_susceptibility = rbind(
+  r0 <- 2.0
+  contact_matrix <- matrix(r0 / 200, 2, 2)
+  demography_vector <- rep(100, 2)
+  p_susceptibility <- rbind(
     c(0.25, 0.75),
     c(0.25, 0.75)
   )
-  susceptibility = rbind(
+  susceptibility <- rbind(
     c(0.25, 0.5), # lower susceptibility overall
     c(0.5, 1.0) # higher susceptibility overall
   )
-  
-  # scale contact matrix and demography vector
-  demography_vector = demography_vector / sum(demography_vector)
-  
+
   epi_outcome <- final_size_grps_cpp(
-    contact_matrix = r0 * contact_matrix,
+    contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     p_susceptibility = p_susceptibility,
     susceptibility = susceptibility
   )
   testthat::expect_vector(
-    epi_outcome, ptype = numeric()
+    epi_outcome,
+    ptype = numeric()
   )
   testthat::expect_false(
     any(is.nan(epi_outcome))
@@ -141,14 +140,16 @@ test_that("Check demo groups with higher suscept. have higher final size", {
   testthat::expect_true(
     all(epi_outcome <= 1.0)
   )
-  
+
   # check that epi_outcome of the second group is higher
   testthat::expect_gt(
     epi_outcome[2], epi_outcome[1]
   )
 })
 
-test_that("Check final size by groups is correct in complex case", {
+# test taken from https://gitlab.com/epidemics-r/code_snippets/-/blob/feature/newton_solver/tests/catch_final_size.cpp#L54
+# same as test in src/test-finalsize_grps.cpp L69
+test_that("Check final size by groups correct in complex case, 01 risk group", {
   # make a contact matrix
   contact_matrix <- c(
     5.329620e-08, 1.321156e-08, 1.832293e-08, 7.743492e-09, 5.888440e-09,
@@ -159,47 +160,36 @@ test_that("Check final size by groups is correct in complex case", {
     7.943038e-09, 1.146566e-08, 1.221124e-08, 1.545822e-08, 8.106812e-09,
     2.267918e-09, 3.324235e-09, 5.993247e-09, 9.049331e-09, 8.106812e-09,
     1.572736e-08
-  ) |> matrix(6, 6)
+  )
+  contact_matrix <- matrix(
+    contact_matrix,
+    nrow = 6, ncol = 6
+  )
 
   # make a demography vector
   demography_vector <- c(
     10831795, 11612456, 13511496,
     11499398, 8167102, 4587765
   )
-  demography_vector = demography_vector / sum(demography_vector)
-  
+
   # get an example r0
-  r0 <- 2.0
+  r0 <- 2
 
-  # a p_susceptibility matrix
-  p_susc <- matrix(0, nrow(contact_matrix), 4) # four susceptibiliy groups
-  # fill p_susceptibility columns manually
-  p_susc[, 1] <- 0.7
-  p_susc[, 2] <- 0.1
-  p_susc[, 3] <- 0.1
-  p_susc[, 4] <- 0.1
-
-  # a susceptibility matrix
-  susc <- matrix(0, nrow(contact_matrix), 4)
-  susc[, 1] <- 1.0
-  susc[, 2] <- 0.7
-  susc[, 3] <- 0.4
-  susc[, 4] <- 0.1
-
-  # scale contact matrix correctly
-  contact_matrix = apply(
-    contact_matrix, 1, function(r) r / demography_vector
-  )
+  # a p_susceptibility matrix and susceptibility matrix
+  # single risk group
+  p_susc <- matrix(1, nrow = nrow(contact_matrix), ncol = 1)
+  susc <- p_susc
 
   epi_outcome <- final_size_grps_cpp(
     contact_matrix = r0 * contact_matrix,
     demography_vector = demography_vector,
     p_susceptibility = p_susc,
-    susceptibility = susc
+    susceptibility = susc, tolerance = 1e-12
   )
   # check that values are numeric, not NaN, and not infinite
   testthat::expect_vector(
-    epi_outcome, ptype = numeric()
+    epi_outcome,
+    ptype = numeric()
   )
   testthat::expect_false(
     any(is.nan(epi_outcome))
@@ -221,7 +211,7 @@ test_that("Check final size by groups is correct in complex case", {
 
   # check that between 30 and 45% of the population is infected
   # TO DO - is that what is being checked?
-  ratio = sum(epi_outcome * demography_vector) / sum(demography_vector)
+  ratio <- sum(epi_outcome * demography_vector) / sum(demography_vector)
 
   testthat::expect_gt(
     ratio, 0.3
@@ -232,9 +222,8 @@ test_that("Check final size by groups is correct in complex case", {
 })
 
 test_that("Check basic final size function works with polymod data", {
-  
-  r0 = 2.0
-  
+  r0 <- 2.0
+
   # checking epi spread function from finalsize
   polymod <- socialmixr::polymod
   contact_data <- socialmixr::contact_matrix(
@@ -243,9 +232,9 @@ test_that("Check basic final size function works with polymod data", {
     age.limits = c(0, 20, 40),
     symmetric = TRUE
   )
-  
+
   demography_vector <- contact_data$demography$proportion
-  
+
   # Scale contact matrix to demography
   contact_matrix <- apply(
     contact_data$matrix, 1, function(r) r / demography_vector
@@ -255,24 +244,25 @@ test_that("Check basic final size function works with polymod data", {
   # TODO: fix the function so that this is not needed any more
   contact_matrix <- matrix(contact_matrix, ncol = 3)
   testthat::expect_true(isSymmetric(contact_matrix))
-  
+
   p_susceptibility <- matrix(1, ncol = 3, nrow = 3)
-  p_susceptibility = apply(p_susceptibility, 1, function(x) {
+  p_susceptibility <- apply(p_susceptibility, 1, function(x) {
     x / sum(x)
   })
-  
+
   susceptibility <- matrix(1, ncol = 3, 3)
-  
+
   epi_outcome <- final_size_grps_cpp(
     contact_matrix = r0 * contact_matrix,
     demography_vector = demography_vector,
     p_susceptibility = p_susceptibility,
     susceptibility = susceptibility
   )
-  
+
   # check that values are numeric, not NaN, and not infinite
   testthat::expect_vector(
-    epi_outcome, ptype = numeric()
+    epi_outcome,
+    ptype = numeric()
   )
   testthat::expect_false(
     any(is.nan(epi_outcome))
@@ -287,6 +277,7 @@ test_that("Check basic final size function works with polymod data", {
 
 # check for errors and messages
 test_that("Check for errors and messages", {
+  r0 <- 2.0
   # checking epi spread function from finalsize
   polymod <- socialmixr::polymod
   contact_data <- socialmixr::contact_matrix(

--- a/tests/testthat/test-finalsize_by_group.R
+++ b/tests/testthat/test-finalsize_by_group.R
@@ -33,21 +33,23 @@ test_that("Check final size calculation is correct in simple case", {
   )
 })
 
+test_that("Check final size calculation simple case r0 = 2", {
   r0 <- 2
-  contact_matrix <- matrix(r0 / 200.0, 2, 2)
-  demography_vector <- rep(100.0, 2) |> as.matrix()
-  psusc <- rep(1.0, 2) |> as.matrix()
-  susc <- rep(1.0, 2) |> as.matrix()
+  contact_matrix <- matrix(r0 / 200, 2, 2)
+  demography_vector <- c(100, 100)
+  p_susceptibility <- matrix(1, 2, 1)
+  susceptibility <- p_susceptibility
 
   epi_outcome <- final_size_grps_cpp(
     contact_matrix = contact_matrix,
     demography_vector = demography_vector,
-    p_susceptibility = psusc,
-    susceptibility = susc
+    p_susceptibility = p_susceptibility,
+    susceptibility = susceptibility
   )
-  
+
   testthat::expect_vector(
-    epi_outcome, ptype = numeric()
+    epi_outcome,
+    ptype = numeric()
   )
   testthat::expect_false(
     any(is.nan(epi_outcome))


### PR DESCRIPTION
This PR tries to determine why multiple tests fail for `final_size_grps_cpp`. This is done by adding yet more tests to try and determine where failures occur. The best guess currently is numerical instability in `solve_final_size_newton`, which leads to `NaN`s and `0`s returned for final sizes.