### PR TITLE
Simplify and improve performance of iterative solver

### DIFF
--- a/R/iterative_solver.R
+++ b/R/iterative_solver.R
@@ -45,12 +45,7 @@ solve_final_size_iterative <- function(contact_matrix,
   epi_final_size[i_here] <- 0.0
 
   # matrix filled by columns
-  contact_matrix_ <- matrix(
-    as.vector(contact_matrix_) *
-      (susceptibility %x% demography_vector), # note Kronecker product
-    nrow = nrow(contact_matrix_),
-    ncol = ncol(contact_matrix_)
-  )
+  contact_matrix_ <- contact_matrix * demography_vector %o% susceptibility
 
   contact_matrix_[i_here, zeros == 1] <- 0.0
 

--- a/R/iterative_solver.R
+++ b/R/iterative_solver.R
@@ -35,8 +35,6 @@ solve_final_size_iterative <- function(contact_matrix,
   # make vector of initial final size guesses = 0.5
   epi_final_size <- rep(0.5, n_dim)
 
-  # replicate contact matrix
-  contact_matrix_ <- contact_matrix
   # set contact_matrix values to zero if there are no contacts among
   # demography groups, or if demography groups are empty
   i_here <- demography_vector == 0 | susceptibility == 0 |

--- a/R/iterative_solver.R
+++ b/R/iterative_solver.R
@@ -55,7 +55,7 @@ solve_final_size_iterative <- function(contact_matrix,
     # contact_matrix_ captured from environment
     s <- as.vector(contact_matrix_ %*% (-epi_final_size_))
 
-    epi_final_size_return_ <- ifelse(zeros == 1.0, 0.0, 1.0)
+    epi_final_size_return_ <- 1 - zeros
     epi_final_size_return_ <- epi_final_size_return_ - (p_susceptibility *
       exp(susceptibility * s))
 
@@ -93,7 +93,7 @@ solve_final_size_iterative <- function(contact_matrix,
 
   # adjust numerical errors
   # relies on TRUE equivalent to 1
-  epi_final_size <- ifelse(zeros, 0.0, epi_final_size)
+  epi_final_size <- epi_final_size * zeros
 
   # return what
   epi_final_size

--- a/R/iterative_solver.R
+++ b/R/iterative_solver.R
@@ -45,7 +45,7 @@ solve_final_size_iterative <- function(contact_matrix,
   # matrix filled by columns
   contact_matrix_ <- contact_matrix * demography_vector %o% susceptibility
 
-  contact_matrix_[i_here, zeros == 1] <- 0.0
+  contact_matrix_[i_here, i_here] <- 0.0
 
   # make a vector to hold final size, empty numeric of size n_dim
   epi_final_size_return <- numeric(n_dim)

--- a/R/iterative_solver.R
+++ b/R/iterative_solver.R
@@ -51,7 +51,7 @@ solve_final_size_iterative <- function(contact_matrix,
   epi_final_size_return <- numeric(n_dim)
 
   # define functions to minimise error in final size estimate
-  fn_f <- function(epi_final_size_, epi_final_size_return_) {
+  fn_f <- function(epi_final_size_) {
     # contact_matrix_ captured from environment
     s <- as.vector(contact_matrix_ %*% (-epi_final_size_))
 
@@ -66,7 +66,7 @@ solve_final_size_iterative <- function(contact_matrix,
   # run over fn_f over epi_final_size (intial guess)
   # and epi_final_size_return (current estimate?)
   for (i in seq(iterations)) {
-    epi_final_size_return <- fn_f(epi_final_size, epi_final_size_return)
+    epi_final_size_return <- fn_f(epi_final_size)
     # get current error
     dpi <- epi_final_size - epi_final_size_return
     error <- sum(abs(dpi))

--- a/R/iterative_solver.R
+++ b/R/iterative_solver.R
@@ -93,7 +93,7 @@ solve_final_size_iterative <- function(contact_matrix,
 
   # adjust numerical errors
   # relies on TRUE equivalent to 1
-  epi_final_size <- epi_final_size * zeros
+  epi_final_size <- epi_final_size * (1 - zeros)
 
   # return what
   epi_final_size

--- a/tests/testthat/test-iterative_solver_vary_r0.R
+++ b/tests/testthat/test-iterative_solver_vary_r0.R
@@ -139,11 +139,19 @@ test_that("Iterative solver works with r0 = 12", {
   psusc <- matrix(1, nrow = 2, ncol = 1)
   susc <- psusc
 
-  epi_outcome <- solve_final_size_iterative(
+  # needed to get demography-risk combinations
+  epi_spread_data <- epi_spread(
     contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     p_susceptibility = psusc,
     susceptibility = susc
+  )
+
+  epi_outcome <- solve_final_size_iterative(
+    contact_matrix = epi_spread_data[["contact_matrix"]],
+    demography_vector = epi_spread_data[["demography_vector"]],
+    p_susceptibility = epi_spread_data[["p_susceptibility"]],
+    susceptibility = epi_spread_data[["susceptibility"]]
   )
 
   # check that solver returns correct types


### PR DESCRIPTION
This PR gathers some minor simplifications and performance improvements to the iterative solver.

- 21afdf47b25389f8cccd8113362fc2fa5ee25a71: I use the outer product instead of the Kronecker product. This removes the need to cast as a vector and then recast a matrix, with the associated risks of filling by rows instead of cols, etc. It is also much more efficient:

  ``` r
  x <- matrix(runif(100), nrow = 10)
  s <- runif(10)
  d <- runif(10)

  microbenchmark::microbenchmark(
    matrix(as.vector(x) * s %x% d, nrow = nrow(x)),
    x * d %o% s,
    check = "identical"
  )
  #> Unit: microseconds
  #>                                            expr    min      lq     mean  median
  #>  matrix(as.vector(x) * s %x% d, nrow = nrow(x)) 23.129 24.1395 25.45444 24.9135
  #>                                     x * d %o% s  4.988  5.3565  5.54035  5.5090
  #>       uq    max neval
  #>  25.2135 92.635   100
  #>   5.6460  8.194   100
  ```

  <sup>Created on 2022-10-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>

- 60786a152a62fbb6319e4a5fd4971f8fc288b4a1: I think this a breadcrumb for a previous version of the code but a copy doesn't seem necessary, neither for technical or readability reasons. Correct?

- 6113d981b1e547bf4c1b3463e3ef475ae83ef3de: Since arithmetic operations on matrices and vectors are usually highly optimized at the hardware level, performance is usually much better than with `ifelse()`:

  ``` r
  x = runif(1000)
  z = round(runif(1000))

  microbenchmark::microbenchmark(
    z * x,
    x[z] <- 0,
    ifelse(z == 0, 0, x),
    times = 1000
  )
  #> Unit: nanoseconds
  #>                  expr   min      lq      mean median      uq     max neval
  #>                 z * x   722  2568.5  2850.425   2703  2961.5   14013  1000
  #>             x[z] <- 0  4935  5269.5  6240.724   5985  6436.5   32966  1000
  #>  ifelse(z == 0, 0, x) 20746 34754.0 39682.862  36045 40616.0 3437236  1000
  ```

  <sup>Created on 2022-10-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>

- f86ec30f9365703b83f59e494e5879438491aa95: I am kind of unsure of what is the correct thing here. It seems strange that there was an unused argument. I simply removed it but it might be the sign that there is actually a bug somewhere in the code.

- 77c516f7819cadd4d196f12f8b12c9d71fcbebb8: Mostly for readability, to make it clear that we're setting to 0 the same elements on rows and cols.

@pratikunterwegs, as the most knowledgeable person about this code, I'm letting you choose who should be the 2nd reviewer besides yourself :slightly_smiling_face:. 

I hope I didn't break anything :crossed_fingers: 