### PR TITLE
Fix test for iterative solver, add epi_spread step

### DIFF
--- a/tests/testthat/test-iterative_solver_vary_r0.R
+++ b/tests/testthat/test-iterative_solver_vary_r0.R
@@ -139,11 +139,19 @@ test_that("Iterative solver works with r0 = 12", {
   psusc <- matrix(1, nrow = 2, ncol = 1)
   susc <- psusc
 
-  epi_outcome <- solve_final_size_iterative(
+  # needed to get demography-risk combinations
+  epi_spread_data <- epi_spread(
     contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     p_susceptibility = psusc,
     susceptibility = susc
+  )
+
+  epi_outcome <- solve_final_size_iterative(
+    contact_matrix = epi_spread_data[["contact_matrix"]],
+    demography_vector = epi_spread_data[["demography_vector"]],
+    p_susceptibility = epi_spread_data[["p_susceptibility"]],
+    susceptibility = epi_spread_data[["susceptibility"]]
   )
 
   # check that solver returns correct types


### PR DESCRIPTION
Fixing a test for the iterative solver, where the `epi_spread` step had been omitted, leading to the test failing. This should help #63 pass @Bisaloo.