### PR TITLE
Fix XML issues

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: *
 
 name: test-coverage
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,6 +23,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          packages: any::XML
           extra-packages: any::covr
           needs: coverage
 


### PR DESCRIPTION
Using `any::XML` in dependencies setup `v2` to fix `XML` compile errors. Errors possibly introduced by reverting to CRAN version of `socialmixr`, which pulls in an older version of `XML` that doesn't compile on R v 4.2.x?