### PR TITLE
Remove default value for r0

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr any::XML
+          extra-packages: any::covr
           needs: coverage
 
       - name: Test coverage

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -125,7 +125,7 @@
 #'   control = control
 #' )
 #'
-final_size <- function(r0 = 2.0,
+final_size <- function(r0,
                        contact_matrix,
                        demography_vector,
                        p_susceptibility,

--- a/man/final_size.Rd
+++ b/man/final_size.Rd
@@ -5,7 +5,7 @@
 \title{Final size of an epidemic}
 \usage{
 final_size(
-  r0 = 2,
+  r0,
   contact_matrix,
   demography_vector,
   p_susceptibility,

--- a/tests/testthat/test-check_output_df.R
+++ b/tests/testthat/test-check_output_df.R
@@ -38,7 +38,8 @@ colnames(susc) <- c("susceptible", "immunised")
 # Test for demography names from named demography vector
 test_that("Finalsize returns correct demography names", {
   epi_outcome <- final_size(
-    contact_matrix = r0 * contact_matrix,
+    r0 = r0,
+    contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     p_susceptibility = psusc,
     susceptibility = susc,
@@ -66,7 +67,8 @@ test_that("Finalsize takes demography names from contact data", {
   colnames(susc) <- c("susceptible", "immunised")
 
   epi_outcome <- final_size(
-    contact_matrix = r0 * contact_matrix,
+    r0 = r0,
+    contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     p_susceptibility = psusc,
     susceptibility = susc,
@@ -94,7 +96,8 @@ test_that("Finalsize generates group names", {
   colnames(susc) <- NULL
 
   epi_outcome <- final_size(
-    contact_matrix = r0 * contact_matrix,
+    r0 = r0,
+    contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     p_susceptibility = psusc,
     susceptibility = susc,

--- a/tests/testthat/test-finalsize_grps_cpp_msgs.R
+++ b/tests/testthat/test-finalsize_grps_cpp_msgs.R
@@ -19,12 +19,15 @@ susceptibility <- matrix(1, ncol = 1, 3)
 # Check final_size works with Newton solver
 # check for errors and messages
 test_that("Check for errors and messages", {
+  r0 <- 2
+  
   # 'wrong' demography vector
   demography_vector <- c(demography_vector, 100)
 
   # expect error on demography vector and contact matrix
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       p_susceptibility = p_susceptibility,
@@ -41,6 +44,7 @@ test_that("Check for errors and messages", {
   # expect error on demography vector and p_susceptibility
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       p_susceptibility = p_susceptibility,
@@ -57,6 +61,7 @@ test_that("Check for errors and messages", {
   # expect error on demography vector and susceptibility
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       p_susceptibility = p_susceptibility,
@@ -73,6 +78,7 @@ test_that("Check for errors and messages", {
   # expect error on p_susceptibility and susceptibility
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       p_susceptibility = p_susceptibility,
@@ -89,6 +95,7 @@ test_that("Check for errors and messages", {
   susceptibility <- matrix(1, ncol = 2, nrow = 3)
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       p_susceptibility = p_susceptibility,
@@ -105,6 +112,7 @@ test_that("Check for errors and messages", {
   p_susceptibility <- p_susceptibility / rowSums(p_susceptibility)
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       p_susceptibility = p_susceptibility,
@@ -119,6 +127,7 @@ test_that("Check for errors and messages", {
   # check for warning when error is much larger than tolerance, iterative
   expect_warning(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       p_susceptibility = p_susceptibility,
@@ -137,6 +146,7 @@ test_that("Check for errors and messages", {
   # check for warning when error is much larger than tolerance, newton
   expect_warning(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       p_susceptibility = p_susceptibility,
@@ -154,6 +164,7 @@ test_that("Check for errors and messages", {
   # expect errors when wrong argument types are passed
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = as.vector(contact_matrix),
       demography_vector = demography_vector,
       p_susceptibility = p_susceptibility,
@@ -163,6 +174,7 @@ test_that("Check for errors and messages", {
   )
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = as.matrix(demography_vector),
       p_susceptibility = p_susceptibility,
@@ -172,6 +184,7 @@ test_that("Check for errors and messages", {
   )
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       p_susceptibility = as.vector(p_susceptibility),
@@ -181,6 +194,7 @@ test_that("Check for errors and messages", {
   )
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       susceptibility = as.vector(susceptibility),
@@ -191,12 +205,14 @@ test_that("Check for errors and messages", {
 })
 
 test_that("Check that eigenvalue checking works", {
+  r0 <- 2
   contact_matrix <- contact_data$matrix
   p_susceptibility <- matrix(1, ncol = 1, nrow = 3)
   susceptibility <- matrix(1, ncol = 1, 3)
 
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       susceptibility = susceptibility,
@@ -208,11 +224,13 @@ test_that("Check that eigenvalue checking works", {
 
 # Check the contents of the control list
 test_that("Check that eigenvalue checking works", {
+  r0 <- 2
   p_susceptibility <- matrix(1, ncol = 1, nrow = 3)
   susceptibility <- matrix(1, ncol = 1, 3)
 
   expect_error(
     final_size(
+      r0 = r0,
       contact_matrix = contact_matrix,
       demography_vector = demography_vector,
       susceptibility = susceptibility,

--- a/tests/testthat/test-iterative_solver_mult_grps.R
+++ b/tests/testthat/test-iterative_solver_mult_grps.R
@@ -12,6 +12,7 @@ test_that("Iterative solver works with multiple risk groups", {
   susc <- matrix(1, nrow = length(demography_vector), ncol = n_risk_grps)
 
   epi_outcome <- final_size(
+    r0 = r0,
     contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     susceptibility = susc,
@@ -64,6 +65,7 @@ test_that("Iterative solver works with multiple risk and age groups", {
   susc <- matrix(1, nrow = n_demo_grps, ncol = n_risk_grps)
 
   epi_outcome <- final_size(
+    r0 = r0,
     contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     susceptibility = susc,

--- a/tests/testthat/test-iterative_solver_vary_r0.R
+++ b/tests/testthat/test-iterative_solver_vary_r0.R
@@ -184,6 +184,7 @@ test_that("Iterative solver works with r0 = 4, locked step size", {
   susc <- psusc
 
   epi_outcome <- final_size(
+    r0 = r0,
     contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     susceptibility = susc,

--- a/tests/testthat/test-newton_solver_mult_grps.R
+++ b/tests/testthat/test-newton_solver_mult_grps.R
@@ -69,6 +69,7 @@ test_that("Newton solver works with multiple risk and age groups", {
   susc <- matrix(1, nrow = n_demo_grps, ncol = n_risk_grps)
 
   epi_outcome <- final_size(
+    r0 = r0,
     contact_matrix = contact_matrix,
     demography_vector = demography_vector,
     susceptibility = susc,


### PR DESCRIPTION
This is the result of the discussion we had about user profiles during the LSHTM meeting yesterday. We think that some users will run functions with the defaults and assume that they got a scientifically valid value.

We would like to prevent this kind of situation by forcing the user to explicitly pass a value for r0.