### PR TITLE
Minor corrections to finalsize

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^README\.Rmd$
 ^\.lintr$
 ^\_pkgdown.yml$
+^cran-comments\.md$

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ Please place an "x" in all the boxes that apply
   
 - [ ] I have the most recent version of finalsize and R
 - [ ] I have found a bug
-- [ ] I have a [reproducible example](http://reprex.tidyverse.org/articles/reprex-dos-and-donts.html)
+- [ ] I have a [reproducible example](https://reprex.tidyverse.org/articles/reprex-dos-and-donts.html)
 - [ ] I want to request a new feature
 
 --------

--- a/.lintr
+++ b/.lintr
@@ -7,4 +7,4 @@ linters: linters_with_tags(
     todo_comment_linter = NULL,
     function_argument_linter = NULL
   )
-
+exclusions: list("R/RcppExports.R")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,14 +6,21 @@ Authors@R:
         person(
             given = "Pratik",
             family = "Gupte",
-            role = c("aut", "cre"),
+            role = c("aut", "cre", "cph"),
             email = "pratik.gupte@lshtm.ac.uk",
             comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819")
         ),
         person(
+            given = "Edwin",
+            family = "Van Leeuwen",
+            role = c("aut", "cph"),
+            email = "edwin.vanleeuwen@ukhsa.gov.uk",
+            comment = c(ORCID = "https://orcid.org/0000-0002-2383-5305")
+        ),
+        person(
             given = "Adam",
             family = "Kucharski",
-            role = c("aut"),
+            role = c("aut", "cph"),
             email = "adam.kucharski@lshtm.ac.uk",
             comment = c(ORCID = "https://orcid.org/0000-0001-8814-9421")
         ),
@@ -30,6 +37,10 @@ Authors@R:
             role = c("ctb"),
             email = "thibaut@data.org",
             comment = c(ORCID = "https://orcid.org/0000-0003-3796-2097")
+        ),
+        person(
+            "London School of Hygiene and Tropical Medicine", 
+            role = c("cph", "fnd")
         )
     )
 Description: Calculate the final size of a susceptible-infectious-recovered epidemic in a population with demographic variation in contact patterns and susceptibility to disease, as discussed in Miller et al. (2012) <doi:10.1007/s11538-012-9749-6>.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: finalsize
-Title: Calculate the Final Size of an Epidemic Outbreak
+Title: Calculate the Final Size of an Epidemic
 Version: 0.1
 Authors@R: 
     c(
@@ -32,7 +32,7 @@ Authors@R:
             comment = c(ORCID = "https://orcid.org/0000-0003-3796-2097")
         )
     )
-Description: Calculate the final size of a susceptible-infectious-recovered epidemic outbreak in a population with demographic variation in contact patterns and susceptibility to disease, as discussed in Miller et al. (2012) <doi:10.1007/s11538-012-9749-6>.
+Description: Calculate the final size of a susceptible-infectious-recovered epidemic in a population with demographic variation in contact patterns and susceptibility to disease, as discussed in Miller et al. (2012) <doi:10.1007/s11538-012-9749-6>.
 License: MIT + file LICENSE
 URL: https://epiverse-trace.github.io/finalsize/, https://github.com/epiverse-trace/finalsize
 BugReports: https://github.com/epiverse-trace/finalsize/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: finalsize
-Title: Calculates Final Size for SIR Epidemic in Heterogeneous Population
+Title: Calculate the Final Size of an Epidemic Outbreak
 Version: 0.1
 Authors@R: 
     c(
@@ -32,20 +32,21 @@ Authors@R:
             comment = c(ORCID = "https://orcid.org/0000-0003-3796-2097")
         )
     )
-Description: Functions for calculating final size for an SIR epidemic in a heterogeneous population, given social contact matrix and demographic data.
-RoxygenNote: 7.2.1
-Roxygen: list(markdown = TRUE)
-Encoding: UTF-8
+Description: Calculate the final size of a susceptible-infectious-recovered epidemic outbreak in a population with demographic variation in contact patterns and susceptibility to disease, as discussed in Miller et al. (2012) <doi:10.1007/s11538-012-9749-6>.
+License: MIT + file LICENSE
+URL: https://epiverse-trace.github.io/finalsize/, https://github.com/epiverse-trace/finalsize
+BugReports: https://github.com/epiverse-trace/finalsize/issues
+Imports:
+    Rcpp
+LinkingTo: 
+    Rcpp,
+    RcppEigen
 Suggests: 
     covr,
     socialmixr,
     testthat (>= 3.0.0),
     xml2
 Config/testthat/edition: 3
-License: MIT + file LICENSE
-Imports:
-    Rcpp
-LinkingTo: 
-    Rcpp,
-    RcppEigen,
-    testthat
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,10 +37,6 @@ Authors@R:
             role = c("ctb"),
             email = "thibaut@data.org",
             comment = c(ORCID = "https://orcid.org/0000-0003-3796-2097")
-        ),
-        person(
-            "London School of Hygiene and Tropical Medicine", 
-            role = c("cph", "fnd")
         )
     )
 Description: Calculate the final size of a susceptible-infectious-recovered epidemic in a population with demographic variation in contact patterns and susceptibility to disease, as discussed in Miller et al. (2012) <doi:10.1007/s11538-012-9749-6>.

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -20,6 +20,7 @@
 #' work well.
 #' @param adapt_step Boolean, whether the solver step rate should be changed
 #' based on the solver error. Defaults to TRUE.
+#' @keywords internal
 #'
 #' @return A vector of final sizes, of the size (N demography groups *
 #' N risk groups).
@@ -42,6 +43,7 @@
 #' the error drops below this tolerance. Defaults to set `1e-6`.
 #' Larger tolerance values are likely to lead to inaccurate final size
 #' estimates.
+#' @keywords internal
 #'
 #' @return A two dimensional array of final sizes per age-risk group.
 .solve_newton <- function(contact_matrix, demography_vector, susceptibility, iterations = 10000L, tolerance = 1e-6) {

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -92,7 +92,7 @@
 #'   susceptibility = susc
 #' )
 #'
-#' # using manually specified solver settings
+#' # using manually specified solver settings for the iterative solver
 #' control <- list(
 #'   iterations = 1000,
 #'   tolerance = 1e-6,

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -241,23 +241,17 @@ final_size <- function(r0,
     )
   }
 
-  # convert to matrix
-  epi_final_size <- matrix(
-    epi_final_size,
-    nrow = length(demography_vector),
-    ncol = ncol(susceptibility)
-  )
   epi_final_size <- data.frame(
     demo_grp = rep(
       names_demography,
-      times = ncol(epi_final_size)
+      times = ncol(susceptibility)
     ),
     susc_grp = rep(
       names_susceptibility,
-      each = nrow(epi_final_size)
+      each = nrow(susceptibility)
     ),
     susceptibility = as.vector(susceptibility),
-    p_infected = as.vector(epi_final_size)
+    p_infected = epi_final_size
   )
   epi_final_size
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/epiverse-trace/finalsize/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/finalsize?branch=main)
 <!-- badges: end -->
 
-_finalsize_ provides quick back-of-the-envelope calculations for the final size of an epidemic outbreak in a population with demographic variation in contact patterns, and variation within and between age groups in their susceptibility to disease.
+_finalsize_ provides calculations for the final size of an epidemic outbreak in a population with demographic variation in contact patterns, and variation within and between age groups in their susceptibility to disease.
 
 _finalsize_ can help provide rough estimates of the effectiveness of pharmaceutical interventions in the form of immunisation programmes, or the effect of naturally acquired immunity through previous infection (see the vignette).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -11,7 +11,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# Calculate the final size of an epidemic <img src="man/figures/logo.png" align="right" width="130"/>
+# _finalsize_: Calculate the final size of an epidemic outbreak <img src="man/figures/logo.png" align="right" width="130"/>
 
 <!-- badges: start -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
@@ -27,7 +27,13 @@ _finalsize_ relies on [Eigen](https://gitlab.com/libeigen/eigen) via [RcppEigen]
 
 ## Installation
 
-You can install the development version of finalsize from [GitHub](https://github.com/) with:
+The package can be installed using
+
+```r
+install.packages("finalsize")
+```
+
+The current development version of _finalsize_ can be installed from [Github](https://github.com/epiverse-trace/finalsize) using the `remotes` package.
 
 ```r
 # install.packages("devtools")
@@ -100,7 +106,7 @@ finalsize::final_size(
 
 ## Help 
 
-To report a bug please open an [issue](https://github.com/epiverse-trace/finalsize/issues/new/choose)
+To report a bug please open an [issue](https://github.com/epiverse-trace/finalsize/issues/new/choose).
 
 ## Contribute
 
@@ -113,4 +119,4 @@ Please note that the `finalsize` project is released with a [Contributor Code of
 
 ## Citation
 
-Kucharski AJ, Kwok KO, Wei VW, Cowling BJ, Read JM, Lessler J, Cummings DA, Riley S. [The contribution of social behaviour to the transmission of influenza A in a human population](https://journals.plos.org/plospathogens/article?id=10.1371/journal.ppat.1004206). PLOS Pathogens 2014;10(6):e1004206 PMID: 24968312
+Kucharski A.J., Kwok K.O., Wei V.W., Cowling B.J., Read J.M., Lessler J., Cummings D.A., Riley S. [The contribution of social behaviour to the transmission of influenza A in a human population](https://journals.plos.org/plospathogens/article?id=10.1371/journal.ppat.1004206). PLOS Pathogens 2014;10(6):e1004206 PMID: 24968312

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/epiverse-trace/finalsize/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/finalsize?branch=main)
 <!-- badges: end -->
 
-_finalsize_ provides calculations for the final size of an epidemic outbreak in a population with demographic variation in contact patterns, and variation within and between age groups in their susceptibility to disease.
+_finalsize_ provides calculations for the final size of an epidemic in a population with demographic variation in contact patterns, and variation within and between age groups in their susceptibility to disease.
 
 _finalsize_ can help provide rough estimates of the effectiveness of pharmaceutical interventions in the form of immunisation programmes, or the effect of naturally acquired immunity through previous infection (see the vignette).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -11,7 +11,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# _finalsize_: Calculate the final size of an epidemic outbreak <img src="man/figures/logo.png" align="right" width="130"/>
+# _finalsize_: Calculate the final size of an epidemic <img src="man/figures/logo.png" align="right" width="130"/>
 
 <!-- badges: start -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Calculate the final size of an epidemic <img src="man/figures/logo.png" align="right" width="130"/>
+# *finalsize*: Calculate the final size of an epidemic outbreak <img src="man/figures/logo.png" align="right" width="130"/>
 
 <!-- badges: start -->
 
@@ -30,8 +30,15 @@ at the London School of Hygiene and Tropical Medicine as part of the
 
 ## Installation
 
-You can install the development version of finalsize from
-[GitHub](https://github.com/) with:
+The package can be installed using
+
+``` r
+install.packages("finalsize")
+```
+
+The current development version of *finalsize* can be installed from
+[Github](https://github.com/epiverse-trace/finalsize) using the
+`remotes` package.
 
 ``` r
 # install.packages("devtools")
@@ -121,7 +128,7 @@ finalsize::final_size(
 ## Help
 
 To report a bug please open an
-[issue](https://github.com/epiverse-trace/finalsize/issues/new/choose)
+[issue](https://github.com/epiverse-trace/finalsize/issues/new/choose).
 
 ## Contribute
 
@@ -138,8 +145,8 @@ By contributing to this project, you agree to abide by its terms.
 
 ## Citation
 
-Kucharski AJ, Kwok KO, Wei VW, Cowling BJ, Read JM, Lessler J, Cummings
-DA, Riley S. [The contribution of social behaviour to the transmission
-of influenza A in a human
+Kucharski A.J., Kwok K.O., Wei V.W., Cowling B.J., Read J.M., Lessler
+J., Cummings D.A., Riley S. [The contribution of social behaviour to the
+transmission of influenza A in a human
 population](https://journals.plos.org/plospathogens/article?id=10.1371/journal.ppat.1004206).
 PLOS Pathogens 2014;10(6):e1004206 PMID: 24968312

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/
 coverage](https://codecov.io/gh/epiverse-trace/finalsize/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/finalsize?branch=main)
 <!-- badges: end -->
 
-*finalsize* provides quick back-of-the-envelope calculations for the
-final size of an epidemic outbreak in a population with demographic
-variation in contact patterns, and variation within and between age
-groups in their susceptibility to disease.
+*finalsize* provides calculations for the final size of an epidemic
+outbreak in a population with demographic variation in contact patterns,
+and variation within and between age groups in their susceptibility to
+disease.
 
 *finalsize* can help provide rough estimates of the effectiveness of
 pharmaceutical interventions in the form of immunisation programmes, or

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# *finalsize*: Calculate the final size of an epidemic outbreak <img src="man/figures/logo.png" align="right" width="130"/>
+# *finalsize*: Calculate the final size of an epidemic <img src="man/figures/logo.png" align="right" width="130"/>
 
 <!-- badges: start -->
 
@@ -10,10 +10,9 @@ MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/
 coverage](https://codecov.io/gh/epiverse-trace/finalsize/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/finalsize?branch=main)
 <!-- badges: end -->
 
-*finalsize* provides calculations for the final size of an epidemic
-outbreak in a population with demographic variation in contact patterns,
-and variation within and between age groups in their susceptibility to
-disease.
+*finalsize* provides calculations for the final size of an epidemic in a
+population with demographic variation in contact patterns, and variation
+within and between age groups in their susceptibility to disease.
 
 *finalsize* can help provide rough estimates of the effectiveness of
 pharmaceutical interventions in the form of immunisation programmes, or

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,5 @@
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+* This is a new release.

--- a/src/iterative_solver.cpp
+++ b/src/iterative_solver.cpp
@@ -26,6 +26,7 @@
 //' work well.
 //' @param adapt_step Boolean, whether the solver step rate should be changed
 //' based on the solver error. Defaults to TRUE.
+//' @keywords internal
 //'
 //' @return A vector of final sizes, of the size (N demography groups *
 //' N risk groups).

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -22,6 +22,7 @@
 //' the error drops below this tolerance. Defaults to set `1e-6`.
 //' Larger tolerance values are likely to lead to inaccurate final size
 //' estimates.
+//' @keywords internal
 //'
 //' @return A two dimensional array of final sizes per age-risk group.
 // [[Rcpp::export(name = ".solve_newton")]]

--- a/tests/testthat/test-iterative_solver_vary_r0.R
+++ b/tests/testthat/test-iterative_solver_vary_r0.R
@@ -190,7 +190,7 @@ test_that("Iterative solver works with r0 = 4, locked step size", {
     susceptibility = susc,
     p_susceptibility = psusc,
     control = list(
-      adapt_step = TRUE
+      adapt_step = FALSE
     )
   )
 


### PR DESCRIPTION
This pull request corrects some minor issues with `finalsize` in order to prepare for a CRAN release. This PR includes commits that tackle the checklist in #96, under the "First release" section.

1. https://github.com/epiverse-trace/finalsize/pull/100/commits/b14fc03b760e325a9e9fb3f447436e74c7585008 fixes #101 
2. https://github.com/epiverse-trace/finalsize/pull/100/commits/9f0750ea8cf386c377a726aeee96c14714880770 fixes #102
3. https://github.com/epiverse-trace/finalsize/pull/100/commits/9f0750ea8cf386c377a726aeee96c14714880770, https://github.com/epiverse-trace/finalsize/pull/100/commits/98313a1d4389a28dfeebd95845a72a80de530fee, https://github.com/epiverse-trace/finalsize/pull/100/commits/44b4ae6426f646addf2ae324bcfbea6360a83a58 fixes #103 
4. https://github.com/epiverse-trace/finalsize/pull/100/commits/068b65e5ba254f7c32161539fa0e37009bfe8f97 adds @BlackEdder as author and adds `cph` role to add `aut` roles. This may see some minor edits to come.
5. Also fixes/checks #105 
