### PR TITLE
Improve Cppcheck workflow

### DIFF
--- a/.github/workflows/Cpp-lint-check.yaml
+++ b/.github/workflows/Cpp-lint-check.yaml
@@ -24,4 +24,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get install cppcheck
-      - run: cppcheck -isrc/RcppExports.cpp --quiet --enable=warning --error-exitcode=1 .
+      - run: cppcheck -i src/RcppExports.cpp --enable=performance,portability,warning,style --error-exitcode=1 src


### PR DESCRIPTION
This a work in progress to improve checks on the C++ code of `finalsize`.
Add more options for `cppcheck`:
1. More clearly ignore RcppExports.cpp
2. Allow full output if any
3. Flag more issues including portability and performance