### PR TITLE
Correct links to starter vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,6 @@ Suggests:
     bookdown,
     scales,
     socialmixr,
-    svglite,
     testthat (>= 3.0.0),
     xml2,
     ggplot2,

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -42,7 +42,7 @@ knitr::opts_chunk$set(
   comment = "#>",
   message = FALSE,
   warning = FALSE,
-  dev = "svglite"
+  dpi = 300
 )
 ```
 

--- a/vignettes/uncertainty_params.Rmd
+++ b/vignettes/uncertainty_params.Rmd
@@ -45,7 +45,7 @@ knitr::opts_chunk$set(
   comment = "#>",
   message = FALSE,
   warning = FALSE,
-  dev = "svglite"
+  dpi = 300
 )
 options(rmarkdown.html_vignette.check_title = FALSE)
 ```

--- a/vignettes/uncertainty_params.Rmd
+++ b/vignettes/uncertainty_params.Rmd
@@ -62,7 +62,7 @@ library(ggplot2)
 
 This example uses social contact data from the [POLYMOD](https://cordis.europa.eu/project/id/502084) project to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
 
-These data are handled just as in the [Basic usage](using_finalsize.html) vignette. This example also considers an infection with an $R_0$ of 2.0.
+These data are handled just as in the [Basic usage](finalsize.html) vignette. This example also considers an infection with an $R_0$ of 2.0.
 
 ```{r}
 # get UK polymod data

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -19,7 +19,7 @@ editor_options:
 Populations are often heterogeneous in their susceptibility to infection following exposure, independent of the exposure risk that comes from different social contact patterns. Such heterogeneity may be age-dependent and vary between age groups. It may also vary within age groups due to prior infection resulting in immunity or due to immunisation. Combinations of within- and between-group variation in susceptibility may also occur, and can be incorporated into final size calculations [ [@miller2012] ](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3506030/).
 
 ::: {.alert .alert-warning}
-**New to _finalsize_?** It may help to read the ["Basic usage"](using_finalsize.html) vignette first!
+**New to _finalsize_?** It may help to read the ["Basic usage"](finalsize.html) vignette first!
 :::
 
 ::: {.alert .alert-primary}
@@ -64,7 +64,7 @@ library(colorspace)
 
 This example uses social contact data from the [POLYMOD](https://cordis.europa.eu/project/id/502084) project to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
 
-These data are handled just as in the ["Basic usage"](using_finalsize.html) vignette, and the code is not displayed here. This example also considers a disease with an $R_0$ of 2.0.
+These data are handled just as in the ["Basic usage"](finalsize.html) vignette, and the code is not displayed here. This example also considers a disease with an $R_0$ of 2.0.
 
 ```{r class.source = 'fold-hide'}
 # get UK polymod data

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -47,7 +47,7 @@ knitr::opts_chunk$set(
   comment = "#>",
   message = FALSE,
   warning = FALSE,
-  dev = "svglite"
+  dpi = 300
 )
 ```
 


### PR DESCRIPTION
- Correct links from articles to the starter vignette.
- Use png images as svg rendering is bad