### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.github/workflows/Cpp-lint-check.yaml
+++ b/.github/workflows/Cpp-lint-check.yaml
@@ -17,11 +17,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
       - run: pip install cpplint
-      - run: cpplint --quiet --exclude="src/RcppExports.cpp" src/*.cpp
+      - run: cpplint --exclude="src/RcppExports.cpp" src/*.cpp
 
   cppcheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get install cppcheck
-      - run: cppcheck -isrc/RcppExports.cpp --quiet --enable=warning --error-exitcode=1 .
+      - run: cppcheck -i src/RcppExports.cpp --enable=style --error-exitcode=1 src

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Authors@R:
     )
 Description: Calculate the final size of a susceptible-infectious-recovered epidemic in a population with demographic variation in contact patterns and susceptibility to disease, as discussed in Miller (2012) <doi:10.1007/s11538-012-9749-6>.
 License: MIT + file LICENSE
-URL: https://epiverse-trace.github.io/finalsize/, https://github.com/epiverse-trace/finalsize
+URL: https://github.com/epiverse-trace/finalsize, https://epiverse-trace.github.io/finalsize/
 BugReports: https://github.com/epiverse-trace/finalsize/issues
 Imports:
     Rcpp

--- a/src/iterative_solver.cpp
+++ b/src/iterative_solver.cpp
@@ -70,7 +70,7 @@ Eigen::ArrayXd solve_final_size_iterative(
   // define functions to minimise error in final size estimate
   auto f = [&contact_matrix_, &susceptibility, &zeros](
                const Eigen::VectorXd &epi_final_size,
-               Eigen::VectorXd &&epi_final_size_return) {
+               Eigen::VectorXd &epi_final_size_return) {
     Eigen::VectorXd s = contact_matrix_ * (-epi_final_size);
     for (int i = 0; i < contact_matrix_.rows(); ++i) {
       if (zeros[i] == 1) {
@@ -81,7 +81,6 @@ Eigen::ArrayXd solve_final_size_iterative(
 
       epi_final_size_return(i) -= exp(susceptibility(i) * s(i));
     }
-    return std::move(epi_final_size_return);
   };
 
   double current_error = step_rate * nDim;
@@ -89,7 +88,7 @@ Eigen::ArrayXd solve_final_size_iterative(
   const double step_change = 1.1;
 
   for (auto i = 0; i < iterations; ++i) {
-    epi_final_size_return = f(epi_final_size, std::move(epi_final_size_return));
+    f(epi_final_size, epi_final_size_return);
 
     Eigen::ArrayXd dpi = epi_final_size - epi_final_size_return.array();
     error = dpi.abs().sum();


### PR DESCRIPTION
This PR implements a few miscellaneous fixes:
1. Corrects the order of URLs in the DESCRIPTION URL field;
2. Use pass-by-reference rather than `std::move` semantics to avoid _Cppcheck_ style warnings;
3. Clarify C++ linting workflow commands.