### PR TITLE
Improve documentation and argument order

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches:
+     - "*"
 
 name: R-CMD-check
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,7 @@ Config/testthat/edition: 3
 SystemRequirements: C++14
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 VignetteBuilder: knitr
 Depends: 
     R (>= 2.10)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,6 @@ LinkingTo:
 Suggests: 
     colorspace,
     covr,
-    data.table,
     knitr,
     bookdown,
     scales,

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -148,7 +148,8 @@ final_size <- function(r0,
       ),
     "Error: contact matrix must have a maximum real eigenvalue of 1.0" =
       (
-        abs(max(eigen(contact_matrix * demography_vector)$values) - 1.0) < 1e-6
+        abs(max(Re(eigen(contact_matrix * demography_vector)$values) - 1.0)) <
+          1e-6
       ),
     "Error: control list names can only be: 'iterations', 'tolerance',
     'step_rate', 'adapt_step'" =

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -33,12 +33,12 @@
 #' @param demography_vector Demography vector. Entry \eqn{v_{i}} gives
 #' proportion of total population in group \eqn{i} (model will normalise
 #' if needed).
+#' @param susceptibility A matrix giving the susceptibility of individuals in
+#' demographic group \eqn{i} and risk group \eqn{j}.
 #' @param p_susceptibility A matrix giving the probability that an individual
 #' in demography group \eqn{i} is in risk (or susceptibility) group \eqn{j}.
 #' Each row represents the overall distribution of individuals in demographic
 #' group \eqn{i} across risk groups, and each row *must sum to 1.0*.
-#' @param susceptibility A matrix giving the susceptibility of individuals in
-#' demographic group \eqn{i} and risk group \eqn{j}.
 #' @param solver Which solver to use. Options are "iterative" (default) or
 #' "newton", for the iterative solver, or the Newton solver, respectively.
 #' Special conditions apply when using the Newton solver, see the `control`
@@ -63,24 +63,25 @@
 #' n_demo_grps <- length(demography_vector)
 #' n_risk_grps <- 3
 #'
-#' # prepare p_susceptibility and susceptibility
-#' psusc <- matrix(
-#'   data = 1, nrow = n_demo_grps, ncol = n_risk_grps
-#' )
-#' psusc <- psusc / rowSums(psusc)
 #' # In this example, all risk groups from all age groups are fully
 #' # susceptible
-#' susc <- matrix(
+#' susceptibility <- matrix(
 #'   data = 1, nrow = n_demo_grps, ncol = n_risk_grps
 #' )
+#'
+#' p_susceptibility <- matrix(
+#'   data = 1, nrow = n_demo_grps, ncol = n_risk_grps
+#' )
+#' # p_susceptibility rows must sum to 1.0
+#' p_susceptibility <- p_susceptibility / rowSums(p_susceptibility)
 #'
 #' # using default arguments for `solver` and `control`
 #' final_size(
 #'   r0 = r0,
 #'   contact_matrix = contact_matrix,
 #'   demography_vector = demography_vector,
-#'   p_susceptibility = psusc,
-#'   susceptibility = susc
+#'   susceptibility = susceptibility,
+#'   p_susceptibility = p_susceptibility
 #' )
 #'
 #' # using manually specified solver settings for the iterative solver
@@ -95,8 +96,8 @@
 #'   r0 = r0,
 #'   contact_matrix = contact_matrix,
 #'   demography_vector = demography_vector,
-#'   p_susceptibility = psusc,
-#'   susceptibility = susc,
+#'   susceptibility = susceptibility,
+#'   p_susceptibility = p_susceptibility,
 #'   solver = "iterative",
 #'   control = control
 #' )
@@ -111,16 +112,16 @@
 #'   r0 = r0,
 #'   contact_matrix = contact_matrix,
 #'   demography_vector = demography_vector,
-#'   p_susceptibility = psusc,
-#'   susceptibility = susc,
+#'   susceptibility = susceptibility,
+#'   p_susceptibility = p_susceptibility,
 #'   solver = "newton",
 #'   control = control
 #' )
 final_size <- function(r0,
                        contact_matrix,
                        demography_vector,
-                       p_susceptibility,
                        susceptibility,
+                       p_susceptibility,
                        solver = c("iterative", "newton"),
                        control = list()) {
   # check arguments input
@@ -210,7 +211,7 @@ final_size <- function(r0,
     )
   )
 
-  # check for names of age groups and susc groups
+  # check for names of age groups and susceptibility groups
   names_demography <- names(demography_vector)
   if (is.null(names_demography)) {
     # check if contact matrix has column names
@@ -225,7 +226,7 @@ final_size <- function(r0,
     }
   }
 
-  # check for susc group names
+  # check for susceptibility group names
   names_susceptibility <- colnames(susceptibility)
   if (is.null(names_susceptibility)) {
     names_susceptibility <- sprintf(

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,8 +41,9 @@ install.packages("finalsize")
 The current development version of _finalsize_ can be installed from [Github](https://github.com/epiverse-trace/finalsize) using the `remotes` package.
 
 ```r
-# install.packages("devtools")
-devtools::install_github("epiverse-trace/finalsize")
+# check whether {remotes} is installed
+if(!require("remotes")) install.packages("remotes")
+remotes::install_github("epiverse-trace/finalsize")
 ```
 
 ## Quick start

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.org/package=finalsize)
 <!-- badges: end -->
 
-_finalsize_ provides calculations for the final size of an epidemic in a population, which is the overall number of infected individuals, depending on a demographic distribution (e.g., age groups) and their contact patterns, accounting for different susceptibility to disease between groups (e.g., from different attack rates or infection prevalences) and within groups (e.g., due to immunization programs).
+_finalsize_ provides calculations for the final size of an epidemic in a population, which is the overall number of infected individuals, depending on a demographic distribution (e.g., age groups) and their contact patterns, accounting for different susceptibility to disease between groups (e.g., due to age-related impaired or dysregulated immune responses) and within groups (e.g., due to immunization programs).
 
 _finalsize_ implements methods outlined in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.org/package=finalsize)
 <!-- badges: end -->
 
-_finalsize_ provides calculations for the final size of an epidemic in a population, which is the overall number of infected individuals, depending on a demographic distribution (e.g., age groups) and their contact patterns, accounting for different susceptibility to disease between groups (e.g., due to age-related impaired or dysregulated immune responses) and within groups (e.g., due to immunization programs).
+_finalsize_ provides calculations for the final size of an epidemic in a population, which is the overall number of infected individuals, depending on a demographic distribution (e.g., age groups) and their contact patterns, accounting for different susceptibility to disease between groups (e.g., due to age-group specific immune responses, such as age-related reduced immune function, or immunity from prior exposure to similar pathogens) and within groups (e.g., due to immunisation programs).
 
 _finalsize_ implements methods outlined in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.org/package=finalsize)
 <!-- badges: end -->
 
-_finalsize_ provides calculations for the final size of an epidemic in a population, which is the overall number of infected individuals, depending on a demographic distribution (e.g., age groups) and their contact patterns, accounting for different susceptibility to disease between groups (e.g., due to age-group specific immune responses, such as age-related reduced immune function, or immunity from prior exposure to similar pathogens) and within groups (e.g., due to immunisation programs).
+_finalsize_ provides calculations for the final size of an epidemic in a population, which is the overall number of infected individuals, depending on a demographic distribution (e.g., age groups) and their contact patterns, accounting for different susceptibility to disease between groups (e.g., due to age-group specific immune responses) and within groups (e.g., due to immunisation programs).
 
 _finalsize_ implements methods outlined in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -85,11 +85,11 @@ r0 <- 1.5 # assumed for pandemic influenza
 
 # Calculate the proportion of individuals infected
 final_size(
-  r0,
-  contact_matrix,
-  demography_vector,
-  p_susceptibility,
-  susceptibility
+  r0 = r0,
+  contact_matrix = contact_matrix,
+  demography_vector = demography_vector,
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility
 )
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.org/package=finalsize)
 <!-- badges: end -->
 
-_finalsize_ provides calculations for the final size of an epidemic in a population with demographic variation in contact patterns, and variation within and between age groups in their susceptibility to disease.
+_finalsize_ provides calculations for the final size of an epidemic in a population, which is the overall number of infected individuals, depending on a demographic distribution (e.g., age groups) and their contact patterns, accounting for different susceptibility to disease between groups (e.g., from different attack rates or infection prevalences) and within groups (e.g., due to immunization programs).
 
 _finalsize_ implements methods outlined in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016.
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.
 population, which is the overall number of infected individuals,
 depending on a demographic distribution (e.g., age groups) and their
 contact patterns, accounting for different susceptibility to disease
-between groups (e.g., due to age-related impaired or dysregulated immune
-responses) and within groups (e.g., due to immunization programs).
+between groups (e.g., due to age-group specific immune responses, such
+as age-related reduced immune function, or immunity from prior exposure
+to similar pathogens) and within groups (e.g., due to immunisation
+programs).
 
 *finalsize* implements methods outlined in Andreasen
 ([2011](#ref-andreasen2011)), Miller ([2012](#ref-miller2012)),

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.
 population, which is the overall number of infected individuals,
 depending on a demographic distribution (e.g., age groups) and their
 contact patterns, accounting for different susceptibility to disease
-between groups (e.g., from different attack rates or infection
-prevalences) and within groups (e.g., due to immunization programs).
+between groups (e.g., due to age-related impaired or dysregulated immune
+responses) and within groups (e.g., due to immunization programs).
 
 *finalsize* implements methods outlined in Andreasen
 ([2011](#ref-andreasen2011)), Miller ([2012](#ref-miller2012)),

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.
 <!-- badges: end -->
 
 *finalsize* provides calculations for the final size of an epidemic in a
-population with demographic variation in contact patterns, and variation
-within and between age groups in their susceptibility to disease.
+population, which is the overall number of infected individuals,
+depending on a demographic distribution (e.g., age groups) and their
+contact patterns, accounting for different susceptibility to disease
+between groups (e.g., from different attack rates or infection
+prevalences) and within groups (e.g., due to immunization programs).
 
 *finalsize* implements methods outlined in Andreasen
 ([2011](#ref-andreasen2011)), Miller ([2012](#ref-miller2012)),
@@ -47,8 +50,9 @@ The current development version of *finalsize* can be installed from
 `remotes` package.
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("epiverse-trace/finalsize")
+# check whether {remotes} is installed
+if(!require("remotes")) install.packages("remotes")
+remotes::install_github("epiverse-trace/finalsize")
 ```
 
 ## Quick start
@@ -95,11 +99,11 @@ r0 <- 1.5 # assumed for pandemic influenza
 
 # Calculate the proportion of individuals infected
 final_size(
-  r0,
-  contact_matrix,
-  demography_vector,
-  p_susceptibility,
-  susceptibility
+  r0 = r0,
+  contact_matrix = contact_matrix,
+  demography_vector = demography_vector,
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility
 )
 #>   demo_grp   susc_grp susceptibility p_infected
 #> 1   [0,20) susc_grp_1            1.0 0.32849966
@@ -139,7 +143,7 @@ citation("finalsize")
 #> 
 #> To cite package 'finalsize' in publications use:
 #> 
-#>   Gupte P, Van Leeuwen E, Kucharski A (2022). _finalsize: Calculate the
+#>   Gupte P, Van Leeuwen E, Kucharski A (2023). _finalsize: Calculate the
 #>   Final Size of an Epidemic_.
 #>   https://github.com/epiverse-trace/finalsize,
 #>   https://epiverse-trace.github.io/finalsize/.
@@ -149,7 +153,7 @@ citation("finalsize")
 #>   @Manual{,
 #>     title = {finalsize: Calculate the Final Size of an Epidemic},
 #>     author = {Pratik Gupte and Edwin {Van Leeuwen} and Adam Kucharski},
-#>     year = {2022},
+#>     year = {2023},
 #>     note = {https://github.com/epiverse-trace/finalsize,
 #> https://epiverse-trace.github.io/finalsize/},
 #>   }

--- a/README.md
+++ b/README.md
@@ -16,10 +16,8 @@ status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.
 population, which is the overall number of infected individuals,
 depending on a demographic distribution (e.g., age groups) and their
 contact patterns, accounting for different susceptibility to disease
-between groups (e.g., due to age-group specific immune responses, such
-as age-related reduced immune function, or immunity from prior exposure
-to similar pathogens) and within groups (e.g., due to immunisation
-programs).
+between groups (e.g., due to age-group specific immune responses) and
+within groups (e.g., due to immunisation programs).
 
 *finalsize* implements methods outlined in Andreasen
 ([2011](#ref-andreasen2011)), Miller ([2012](#ref-miller2012)),

--- a/data-raw/polymod_uk.R
+++ b/data-raw/polymod_uk.R
@@ -14,7 +14,7 @@ contact_matrix <- t(polymod_uk$matrix)
 demography_vector <- polymod_uk$demography$population
 
 # scale contacts by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 polymod_uk <- list(

--- a/man/final_size.Rd
+++ b/man/final_size.Rd
@@ -8,8 +8,8 @@ final_size(
   r0,
   contact_matrix,
   demography_vector,
-  p_susceptibility,
   susceptibility,
+  p_susceptibility,
   solver = c("iterative", "newton"),
   control = list()
 )
@@ -24,13 +24,13 @@ number of contacts in group \eqn{i} reported by participants in group \eqn{j}}
 proportion of total population in group \eqn{i} (model will normalise
 if needed).}
 
+\item{susceptibility}{A matrix giving the susceptibility of individuals in
+demographic group \eqn{i} and risk group \eqn{j}.}
+
 \item{p_susceptibility}{A matrix giving the probability that an individual
 in demography group \eqn{i} is in risk (or susceptibility) group \eqn{j}.
 Each row represents the overall distribution of individuals in demographic
 group \eqn{i} across risk groups, and each row \emph{must sum to 1.0}.}
-
-\item{susceptibility}{A matrix giving the susceptibility of individuals in
-demographic group \eqn{i} and risk group \eqn{j}.}
 
 \item{solver}{Which solver to use. Options are "iterative" (default) or
 "newton", for the iterative solver, or the Newton solver, respectively.
@@ -88,24 +88,25 @@ demography_vector <- polymod_uk$demography_vector
 n_demo_grps <- length(demography_vector)
 n_risk_grps <- 3
 
-# prepare p_susceptibility and susceptibility
-psusc <- matrix(
-  data = 1, nrow = n_demo_grps, ncol = n_risk_grps
-)
-psusc <- psusc / rowSums(psusc)
 # In this example, all risk groups from all age groups are fully
 # susceptible
-susc <- matrix(
+susceptibility <- matrix(
   data = 1, nrow = n_demo_grps, ncol = n_risk_grps
 )
+
+p_susceptibility <- matrix(
+  data = 1, nrow = n_demo_grps, ncol = n_risk_grps
+)
+# p_susceptibility rows must sum to 1.0
+p_susceptibility <- p_susceptibility / rowSums(p_susceptibility)
 
 # using default arguments for `solver` and `control`
 final_size(
   r0 = r0,
   contact_matrix = contact_matrix,
   demography_vector = demography_vector,
-  p_susceptibility = psusc,
-  susceptibility = susc
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility
 )
 
 # using manually specified solver settings for the iterative solver
@@ -120,8 +121,8 @@ final_size(
   r0 = r0,
   contact_matrix = contact_matrix,
   demography_vector = demography_vector,
-  p_susceptibility = psusc,
-  susceptibility = susc,
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility,
   solver = "iterative",
   control = control
 )
@@ -136,8 +137,8 @@ final_size(
   r0 = r0,
   contact_matrix = contact_matrix,
   demography_vector = demography_vector,
-  p_susceptibility = psusc,
-  susceptibility = susc,
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility,
   solver = "newton",
   control = control
 )

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -16,7 +16,7 @@ demography_vector <- contact_data$demography$population
 names(demography_vector) <- contact_data$demography$age.group
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 n_demo_grps <- length(demography_vector)

--- a/tests/testthat/test-messages.R
+++ b/tests/testthat/test-messages.R
@@ -13,7 +13,7 @@ contact_matrix <- t(contact_data$matrix)
 demography_vector <- contact_data$demography$population
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 p_susceptibility <- matrix(1, ncol = 1, nrow = 3)

--- a/tests/testthat/test-newton_solver.R
+++ b/tests/testthat/test-newton_solver.R
@@ -16,7 +16,7 @@ demography_vector <- contact_data$demography$population
 names(demography_vector) <- contact_data$demography$age.group
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 n_demo_grps <- length(demography_vector)

--- a/tests/testthat/test-solver_options.R
+++ b/tests/testthat/test-solver_options.R
@@ -16,7 +16,7 @@ demography_vector <- contact_data$demography$population
 names(demography_vector) <- contact_data$demography$age.group
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 n_demo_grps <- length(demography_vector)

--- a/tests/testthat/test-solver_speedups.R
+++ b/tests/testthat/test-solver_speedups.R
@@ -16,7 +16,7 @@ demography_vector <- contact_data$demography$population
 names(demography_vector) <- contact_data$demography$age.group
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 n_demo_grps <- length(demography_vector)

--- a/tests/testthat/test-statistical_correctness.R
+++ b/tests/testthat/test-statistical_correctness.R
@@ -202,7 +202,7 @@ contact_matrix <- t(contact_data$matrix)
 demography_vector <- contact_data$demography$population
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 r0 <- 2.0

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -70,7 +70,7 @@ r0 <- 2.0
 
 ## Getting and preparing contact and demography data
 
-This example uses social contact data from the [POLYMOD](https://journals.plos.org/plosmedicine/article?id=10.1371/journal.pmed.0050074) project to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
+This example uses social contact data from the POLYMOD project [@mossong2008] to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
 
 The contact data are divided into five age groups: 0 -- 4, 5 -- 17, 18 -- 39, 40 -- 64, and 65 and over, specified using the `age.limits` argument in `socialmixr::contact_matrix()`.
 The `symmetric = TRUE` argument to `socialmixr::contact_matrix()` returns a symmetric contact matrix, so that the contacts reported by group $\{i\}$ of individuals from group $\{j\}$ are the same as those reported by group $\{j\}$ of group $\{i\}$.

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -189,15 +189,17 @@ final_size_data <- final_size(
 
 # view the output data frame
 final_size_data
+```
 
-# order demographic groups
+### Visualise final sizes
+
+```{r class.source = 'fold.hide'}
+# order demographic groups as factors
 final_size_data$demo_grp <- factor(
   final_size_data$demo_grp,
   levels = demography_data$age.group
 )
 ```
-
-### Visualise final sizes
 
 ```{r fig.cap ="Final size of an SIR epidemic in each age group. The final size is the cumulative number of infections in each age group over the course of the epidemic, expressed as a proportion of the respective age group.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
 # plot data

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -102,7 +102,7 @@ demography_data <- contact_data$demography
 # scale the contact matrix so the largest eigenvalue is 1.0
 # this is to ensure that the overall epidemic dynamics correctly reflect
 # the assumed value of R0
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 
 # divide each row of the contact matrix by the corresponding demography
 # this reflects the assumption that each individual in group {j} make contacts

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -208,12 +208,14 @@ ggplot(final_size_data) +
     aes(
       demo_grp, p_infected
     ),
-    fill = "lightgrey",
-    col = "black"
+    colour = "black", fill = "grey"
   ) +
   scale_y_continuous(
     labels = scales::percent,
     limits = c(0, 1)
+  ) +
+  expand_limits(
+    x = c(0.5, nrow(final_size_data) + 0.5)
   ) +
   theme_classic() +
   coord_cartesian(
@@ -260,8 +262,10 @@ ggplot(final_size_data) +
     aes(
       x = demo_grp, y = n_infected
     ),
-    fill = "lightgrey",
-    col = "black"
+    fill = "grey", col = "black"
+  ) +
+  expand_limits(
+    x = c(0.5, nrow(final_size_data) + 0.5)
   ) +
   scale_y_continuous(
     labels = scales::comma_format(

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -46,23 +46,14 @@ knitr::opts_chunk$set(
 )
 ```
 
-## Getting _finalsize_
-
-The _finalsize_ package is currently available on [Github](https://github.com/epiverse-trace/finalsize), and can be installed using the `remotes` or `devtools` packages.
-
-```r
-# first install the remotes packages
-install.packages("remotes")
-
-# install finalsize using remotes
-remotes::install_github("epiverse-trace/finalsize")
-```
-
 ```{r}
+# load finalsize
 library(finalsize)
 
 # load necessary packages
-library(data.table)
+if (!require("socialmixr")) install.packages("socialmixr")
+if (!require("ggplot2")) install.packages("ggplot2")
+
 library(ggplot2)
 ```
 
@@ -79,9 +70,9 @@ r0 <- 2.0
 
 ## Getting and preparing contact and demography data
 
-This example uses social contact data from the [POLYMOD](https://cordis.europa.eu/project/id/502084) project to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
+This example uses social contact data from the [POLYMOD](https://journals.plos.org/plosmedicine/article?id=10.1371/journal.pmed.0050074) project to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
 
-The contact data are divided into five age groups: 0 -- 5, 5 -- 18, 18 -- 40, 40 -- 65, and 65 and over, specified using the `age.limits` argument in `socialmixr::contact_matrix()`.
+The contact data are divided into five age groups: 0 -- 4, 5 -- 17, 18 -- 39, 40 -- 64, and 65 and over, specified using the `age.limits` argument in `socialmixr::contact_matrix()`.
 The `symmetric = TRUE` argument to `socialmixr::contact_matrix()` returns a symmetric contact matrix, so that the contacts reported by group $\{i\}$ of individuals from group $\{j\}$ are the same as those reported by group $\{j\}$ of group $\{i\}$.
 
 The demographic data --- the number of individuals in each age group --- is also available through `socialmixr::contact_matrix()`.
@@ -95,6 +86,13 @@ contact_data <- socialmixr::contact_matrix(
   age.limits = c(0, 5, 18, 40, 65),
   symmetric = TRUE
 )
+
+# view the elements of the contact data list
+# the contact matrix
+contact_data$matrix
+
+# the demography data
+contact_data$demography
 
 # get the contact matrix and demography data
 contact_matrix <- t(contact_data$matrix)
@@ -189,6 +187,9 @@ final_size_data <- final_size(
   p_susceptibility = p_susc_uniform
 )
 
+# view the output data frame
+final_size_data
+
 # order demographic groups
 final_size_data$demo_grp <- factor(
   final_size_data$demo_grp,
@@ -233,7 +234,7 @@ The example below show how this can be done.
 demography_data <- contact_data$demography
 
 # merge final size counts with demography vector
-final_size_data <- merge.data.table(
+final_size_data <- merge(
   final_size_data,
   demography_data,
   by.x = "demo_grp",
@@ -251,7 +252,7 @@ final_size_data$n_infected <- final_size_data$p_infected *
   final_size_data$population
 ```
 
-```{r fig.cap="Final size of an epidemic outbreak in a population, for different values of infection $R_0$. Converting the final size proportions in each age group to counts shows that individuals aged 18 -- 65 make up the bulk of cases in this scenario. This may be attributed to this being both the largest age range in the analysis (more years in this range than any other), and because more people fall into this wide range than others. Contrast this figure with the one above, in which similar _proportions_ of each age group are infected.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
+```{r fig.cap="Final size of an epidemic outbreak in a population, for different values of infection $R_0$. Converting the final size proportions in each age group to counts shows that individuals aged 18 -- 64 make up the bulk of cases in this scenario. This may be attributed to this being both the largest age range in the analysis (more years in this range than any other), and because more people fall into this wide range than others. Contrast this figure with the one above, in which similar _proportions_ of each age group are infected.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
 ggplot(final_size_data) +
   geom_col(
     aes(

--- a/vignettes/references.bib
+++ b/vignettes/references.bib
@@ -29,6 +29,88 @@
   keywords = {Exact master equation,Final epidemic size,Mean-field model,SIR epidemic}
 }
 
+@article{cowling2012,
+  title = {Increased {{Risk}} of {{Noninfluenza Respiratory Virus Infections Associated With Receipt}} of {{Inactivated Influenza Vaccine}}},
+  author = {Cowling, Benjamin J. and Fang, Vicky J. and Nishiura, Hiroshi and Chan, Kwok-Hung and Ng, Sophia and Ip, Dennis K. M. and Chiu, Susan S. and Leung, Gabriel M. and Peiris, J. S. Malik},
+  year = {2012},
+  month = jun,
+  journal = {Clinical Infectious Diseases},
+  volume = {54},
+  number = {12},
+  pages = {1778--1783},
+  issn = {1058-4838},
+  doi = {10.1093/cid/cis307},
+  abstract = {We randomized 115 children to trivalent inactivated influenza vaccine (TIV) or placebo. Over the following 9 months, TIV recipients had an increased risk of virologically-confirmed non-influenza infections (relative risk: 4.40; 95\% confidence interval: 1.31-14.8). Being protected against influenza, TIV recipients may lack temporary non-specific immunity that protected against other respiratory viruses.}
+}
+
+@article{davies2020,
+  title = {Age-Dependent Effects in the Transmission and Control of {{COVID-19}} Epidemics},
+  author = {Davies, Nicholas G. and Klepac, Petra and Liu, Yang and Prem, Kiesha and Jit, Mark and Eggo, Rosalind M.},
+  year = {2020},
+  month = aug,
+  journal = {Nature Medicine},
+  volume = {26},
+  number = {8},
+  pages = {1205--1211},
+  publisher = {{Nature Publishing Group}},
+  issn = {1546-170X},
+  doi = {10.1038/s41591-020-0962-9},
+  abstract = {The COVID-19 pandemic has shown a markedly low proportion of cases among children1\textendash 4. Age disparities in observed cases could be explained by children having lower susceptibility to infection, lower propensity to show clinical symptoms or both. We evaluate these possibilities by fitting an age-structured mathematical model to epidemic data from China, Italy, Japan, Singapore, Canada and South Korea. We estimate that susceptibility to infection in individuals under 20 years of age is approximately half that of adults aged over 20 years, and that clinical symptoms manifest in 21\% (95\% credible interval: 12\textendash 31\%) of infections in 10- to 19-year-olds, rising to 69\% (57\textendash 82\%) of infections in people aged over 70 years. Accordingly, we find that interventions aimed at children might have a relatively small impact on reducing SARS-CoV-2 transmission, particularly if the transmissibility of subclinical infections is low. Our age-specific clinical fraction and susceptibility estimates have implications for the expected global burden of COVID-19, as a result of demographic differences across settings. In countries with younger population structures\textemdash such as many low-income countries\textemdash the expected per capita incidence of clinical cases would be lower than in countries with older population structures, although it is likely that comorbidities in low-income countries will also influence disease severity. Without effective control measures, regions with relatively older populations could see disproportionally more cases of COVID-19, particularly in the later stages of an unmitigated epidemic.},
+  copyright = {2020 The Author(s), under exclusive licence to Springer Nature America, Inc.},
+  langid = {english},
+  keywords = {Epidemiology,Infectious diseases,Viral transmission}
+}
+
+@article{franco2022,
+  title = {Inferring Age-Specific Differences in Susceptibility to and Infectiousness upon {{SARS-CoV-2}} Infection Based on {{Belgian}} Social Contact Data},
+  author = {Franco, Nicolas and Coletti, Pietro and Willem, Lander and Angeli, Leonardo and Lajot, Adrien and Abrams, Steven and Beutels, Philippe and Faes, Christel and Hens, Niel},
+  year = {2022},
+  month = mar,
+  journal = {PLOS Computational Biology},
+  volume = {18},
+  number = {3},
+  pages = {e1009965},
+  publisher = {{Public Library of Science}},
+  issn = {1553-7358},
+  doi = {10.1371/journal.pcbi.1009965},
+  abstract = {Several important aspects related to SARS-CoV-2 transmission are not well known due to a lack of appropriate data. However, mathematical and computational tools can be used to extract part of this information from the available data, like some hidden age-related characteristics. In this paper, we present a method to investigate age-specific differences in transmission parameters related to susceptibility to and infectiousness upon contracting SARS-CoV-2 infection. More specifically, we use panel-based social contact data from diary-based surveys conducted in Belgium combined with the next generation principle to infer the relative incidence and we compare this to real-life incidence data. Comparing these two allows for the estimation of age-specific transmission parameters. Our analysis implies the susceptibility in children to be around half of the susceptibility in adults, and even lower for very young children (preschooler). However, the probability of adults and the elderly to contract the infection is decreasing throughout the vaccination campaign, thereby modifying the picture over time.},
+  langid = {english},
+  keywords = {Children,Epidemiology,Infectious disease epidemiology,Respiratory infections,SARS CoV 2,Vaccination and immunization,Vector-borne diseases,Virus testing}
+}
+
+@article{huang2020,
+  title = {A Systematic Review of Antibody Mediated Immunity to Coronaviruses: Kinetics, Correlates of Protection, and Association with Severity},
+  shorttitle = {A Systematic Review of Antibody Mediated Immunity to Coronaviruses},
+  author = {Huang, Angkana T. and {Garcia-Carreras}, Bernardo and Hitchings, Matt D. T. and Yang, Bingyi and Katzelnick, Leah C. and Rattigan, Susan M. and Borgert, Brooke A. and Moreno, Carlos A. and Solomon, Benjamin D. and {Trimmer-Smith}, Luke and Etienne, Veronique and {Rodriguez-Barraquer}, Isabel and Lessler, Justin and Salje, Henrik and Burke, Donald S. and Wesolowski, Amy and Cummings, Derek A. T.},
+  year = {2020},
+  month = sep,
+  journal = {Nature Communications},
+  volume = {11},
+  number = {1},
+  pages = {4704},
+  publisher = {{Nature Publishing Group}},
+  issn = {2041-1723},
+  doi = {10.1038/s41467-020-18450-4},
+  abstract = {Many public health responses and modeled scenarios for COVID-19 outbreaks caused by SARS-CoV-2 assume that infection results in an immune response that protects individuals from future infections or illness for some amount of time. The presence or absence of protective immunity due to infection or vaccination (when available) will affect future transmission and illness severity. Here, we review the scientific literature on antibody immunity to coronaviruses, including SARS-CoV-2 as well as the related SARS-CoV, MERS-CoV and endemic human coronaviruses (HCoVs). We reviewed 2,452 abstracts and identified 491 manuscripts relevant to 5 areas of focus: 1) antibody kinetics, 2) correlates of protection, 3) immunopathogenesis, 4) antigenic diversity and cross-reactivity, and 5) population seroprevalence. While further studies of SARS-CoV-2 are necessary to determine immune responses, evidence from other coronaviruses can provide clues and guide future research.},
+  copyright = {2020 The Author(s)},
+  langid = {english},
+  keywords = {Antibodies,SARS-CoV-2,Viral host response,Viral infection}
+}
+
+@article{iyer2020,
+  title = {Persistence and Decay of Human Antibody Responses to the Receptor Binding Domain of {{SARS-CoV-2}} Spike Protein in {{COVID-19}} Patients},
+  author = {Iyer, Anita S. and Jones, Forrest K. and Nodoushani, Ariana and Kelly, Meagan and Becker, Margaret and Slater, Damien and Mills, Rachel and Teng, Erica and Kamruzzaman, Mohammad and {Garcia-Beltran}, Wilfredo F. and Astudillo, Michael and Yang, Diane and Miller, Tyler E. and Oliver, Elizabeth and Fischinger, Stephanie and Atyeo, Caroline and Iafrate, A. John and Calderwood, Stephen B. and Lauer, Stephen A. and Yu, Jingyou and Li, Zhenfeng and Feldman, Jared and Hauser, Blake M. and Caradonna, Timothy M. and Branda, John A. and Turbett, Sarah E. and LaRocque, Regina C. and Mellon, Guillaume and Barouch, Dan H. and Schmidt, Aaron G. and Azman, Andrew S. and Alter, Galit and Ryan, Edward T and Harris, Jason B. and Charles, Richelle C.},
+  year = {2020},
+  month = oct,
+  journal = {Science Immunology},
+  volume = {5},
+  number = {52},
+  pages = {eabe0367},
+  publisher = {{American Association for the Advancement of Science}},
+  doi = {10.1126/sciimmunol.abe0367},
+  abstract = {We measured plasma and/or serum antibody responses to the receptor-binding domain (RBD) of the spike (S) protein of SARS-CoV-2 in 343 North American patients infected with SARS-CoV-2 (of which 93\% required hospitalization) up to 122 days after symptom onset and compared them to responses in 1548 individuals whose blood samples were obtained prior to the pandemic. After setting seropositivity thresholds for perfect specificity (100\%), we estimated sensitivities of 95\% for IgG, 90\% for IgA, and 81\% for IgM for detecting infected individuals between 15 and 28 days after symptom onset. While the median time to seroconversion was nearly 12 days across all three isotypes tested, IgA and IgM antibodies against RBD were short-lived with median times to seroreversion of 71 and 49 days after symptom onset. In contrast, anti-RBD IgG responses decayed slowly through 90 days with only 3 seropositive individuals seroreverting within this time period. IgG antibodies to SARS-CoV-2 RBD were strongly correlated with anti-S neutralizing antibody titers, which demonstrated little to no decrease over 75 days since symptom onset. We observed no cross-reactivity of the SARS-CoV-2 RBD-targeted antibodies with other widely circulating coronaviruses (HKU1, 229 E, OC43, NL63). These data suggest that RBD-targeted antibodies are excellent markers of previous and recent infection, that differential isotype measurements can help distinguish between recent and older infections, and that IgG responses persist over the first few months after infection and are highly correlated with neutralizing antibodies.}
+}
+
 @article{kucharski2014,
   title = {The Contribution of Social Behaviour to the Transmission of Influenza {{A}} in a Human Population},
   author = {Kucharski, Adam J. and Kwok, Kin O. and Wei, Vivian W. I. and Cowling, Benjamin J. and Read, Jonathan M. and Lessler, Justin and Cummings, Derek A. and Riley, Steven},
@@ -61,4 +143,35 @@
   abstract = {Final size relations are known for many epidemic models. The derivations are often tedious and difficult, involving indirect methods to solve a system of integro-differential equations. Often when the details of the disease or population change, the final size relation does not. An alternate approach to deriving final sizes has been suggested. This approach directly considers the underlying stochastic process of the epidemic rather than the approximating deterministic equations and gives insight into why the relations hold. It has not been widely used. We suspect that this is because it appears to be less rigorous. In this note we investigate this approach more fully and show that under very weak assumptions (which are satisfied in all conditions we are aware of for which final size relations exist) it can be made rigorous. In particular the assumptions must hold whenever integro-differential equations exist, but they may also hold in cases without such equations. Thus the use of integro-differential equations to find a final size relation is unnecessary and a simpler, more general method can be applied.},
   pmcid = {PMC3506030},
   pmid = {22829179}
+}
+
+@article{mossong2008,
+  title = {Social {{Contacts}} and {{Mixing Patterns Relevant}} to the {{Spread}} of {{Infectious Diseases}}},
+  author = {Mossong, Jo{\"e}l and Hens, Niel and Jit, Mark and Beutels, Philippe and Auranen, Kari and Mikolajczyk, Rafael and Massari, Marco and Salmaso, Stefania and Tomba, Gianpaolo Scalia and Wallinga, Jacco and Heijne, Janneke and {Sadkowska-Todys}, Malgorzata and Rosinska, Magdalena and Edmunds, W. John},
+  year = {2008},
+  month = mar,
+  journal = {PLOS Medicine},
+  volume = {5},
+  number = {3},
+  pages = {e74},
+  publisher = {{Public Library of Science}},
+  issn = {1549-1676},
+  doi = {10.1371/journal.pmed.0050074},
+  abstract = {Background Mathematical modelling of infectious diseases transmitted by the respiratory or close-contact route (e.g., pandemic influenza) is increasingly being used to determine the impact of possible interventions. Although mixing patterns are known to be crucial determinants for model outcome, researchers often rely on a priori contact assumptions with little or no empirical basis. We conducted a population-based prospective survey of mixing patterns in eight European countries using a common paper-diary methodology. Methods and Findings 7,290 participants recorded characteristics of 97,904 contacts with different individuals during one day, including age, sex, location, duration, frequency, and occurrence of physical contact. We found that mixing patterns and contact characteristics were remarkably similar across different European countries. Contact patterns were highly assortative with age: schoolchildren and young adults in particular tended to mix with people of the same age. Contacts lasting at least one hour or occurring on a daily basis mostly involved physical contact, while short duration and infrequent contacts tended to be nonphysical. Contacts at home, school, or leisure were more likely to be physical than contacts at the workplace or while travelling. Preliminary modelling indicates that 5- to 19-year-olds are expected to suffer the highest incidence during the initial epidemic phase of an emerging infection transmitted through social contacts measured here when the population is completely susceptible. Conclusions To our knowledge, our study provides the first large-scale quantitative approach to contact patterns relevant for infections transmitted by the respiratory or close-contact route, and the results should lead to improved parameterisation of mathematical models used to design control strategies.},
+  langid = {english},
+  keywords = {Age groups,Epidemiology,Europe,Infectious disease epidemiology,Infectious diseases,Mathematical models,Respiratory infections,Surveys}
+}
+
+@article{tsagarakis2018,
+  title = {Age-Related Prevalence of Common Upper Respiratory Pathogens, Based on the Application of the {{FilmArray Respiratory}} Panel in a Tertiary Hospital in {{Greece}}},
+  author = {Tsagarakis, Nikolaos J. and Sideri, Anthi and Makridis, Panagiotis and Triantafyllou, Argyro and Stamoulakatou, Alexandra and Papadogeorgaki, Eleni},
+  year = {2018},
+  month = jun,
+  journal = {Medicine},
+  volume = {97},
+  number = {22},
+  pages = {e10903},
+  doi = {10.1097/MD.0000000000010903},
+  abstract = {The FilmArray Respiratory Panel (FA-RP) is an FDA certified multiplex PCR that can detect 17 viruses and 3 bacteria responsible for upper respiratory tract infections, thus it is potentially useful to the assessment of the age-related prevalence of these pathogens.         In this observational study, we retrospectively analyzed the results of all the respiratory samples, which had been processed during 1 year-period (November 2015 to November 2016) with the FA-RP, in the Central Laboratories of Hygeia \& Mitera General Hospitals of Athens, Greece. In order to have an age-related distribution, the following age groups were implemented: ({$<$}2), ({$\geq$}2, {$<$}5), ({$\geq$}5, {$<$}10), ({$\geq$}10, {$<$}18), ({$\geq$}18, {$<$}45), ({$\geq$}45, {$<$}65), and ({$\geq$}65) years old.         Among 656 respiratory samples tested, 362 (55\%) were from male and 294 (45\%) from female patients, while 356 (54.3\%) were positive and 300 (45.7\%) negative. In the first age-group ({$<$}2), 41/121 samples (33.9\%) revealed human rhinovirus/enterovirus (HRV) and 16 (13.2\%) adenovirus (Adv), followed by respiratory syncytial virus (RSV), coronavirus, human metapneumovirus (Hmpv), and parainfluenza viruses (PIV). In the age-group ({$\geq$}2, {$<$}5), Adv predominated with 37/147 samples (25.2\%), followed by HRV, RSV, coronavirus (all types), and influenza, Hmpv and PIV. In the age-group ({$\geq$}5, {$<$}10), HRV was identified in 25/80 samples (31.3\%), Adv in 18 (22.5\%), influenza in 11 (13.8\%), and Hmpv in 6 (7.5\%). Influenza predominated in the age-group ({$\geq$}10, {$<$}18), with 4/22 samples (18.2\%), while in the remaining age-groups ({$\geq$}18), HRV was the commonest isolated pathogen, 33/286 (11.5\%), followed by influenza with 20 (7\%) (influenza A H1-2009, 11/20).         In our patient series, HRV seemed to prevail in most age-groups, followed by Adv, although Influenza was the second most frequent pathogen isolated in the age-groups ({$\geq$}18). Moreover, increasing age corresponded to increasing possibility of having a negative sample, indicating that FilmArray may be more useful before adolescence.},
+  langid = {american}
 }

--- a/vignettes/uncertainty_params.Rmd
+++ b/vignettes/uncertainty_params.Rmd
@@ -19,7 +19,7 @@ editor_options:
 Epidemic final size calculations are sensitive to input data such as the $R_0$ of the infection. Such values can often be uncertain in the early stages of an outbreak. This uncertainty can be included in final size calculations by running `final_size()` for values drawn from a distribution, and summarising the outcomes.
 
 ::: {.alert .alert-warning}
-**New to _finalsize_?** It may help to read earlier vignettes first!
+**New to _finalsize_?** It may help to read the ["Get started"](finalsize.html) or ["Modelling heterogeneous susceptibility"](varying_susceptibility.Rmd) vignettes first!
 :::
 
 ::: {.alert .alert-primary}
@@ -65,7 +65,7 @@ library(ggplot2)
 
 This example uses social contact data from the [POLYMOD](https://cordis.europa.eu/project/id/502084) project to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
 
-These data are handled just as in the [Basic usage](finalsize.html) vignette. This example also considers an infection with an $R_0$ of 2.0.
+These data are handled just as in the ["Get started"](finalsize.html) vignette. This example also considers an infection with an $R_0$ of 2.0.
 
 ```{r}
 # get UK polymod data

--- a/vignettes/uncertainty_params.Rmd
+++ b/vignettes/uncertainty_params.Rmd
@@ -82,7 +82,7 @@ contact_matrix <- t(contact_data$matrix)
 demography_vector <- contact_data$demography$population
 
 # scale the contact matrix so the largest eigenvalue is 1.0
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 
 # divide each row of the contact matrix by the corresponding demography
 contact_matrix <- contact_matrix / demography_vector

--- a/vignettes/uncertainty_params.Rmd
+++ b/vignettes/uncertainty_params.Rmd
@@ -51,10 +51,13 @@ options(rmarkdown.html_vignette.check_title = FALSE)
 ```
 
 ```{r setup, message=FALSE, warning=FALSE, class.source = 'fold-hide'}
+# load finalsize
 library(finalsize)
 
 # load necessary packages
-library(data.table)
+if (!require("socialmixr")) install.packages("socialmixr")
+if (!require("ggplot2")) install.packages("ggplot2")
+
 library(ggplot2)
 ```
 
@@ -142,7 +145,7 @@ final_size_data <- Map(
 )
 
 # combine data
-final_size_data <- rbindlist(final_size_data)
+final_size_data <- Reduce(x = final_size_data, f = rbind)
 
 # order age groups
 final_size_data$demo_grp <- factor(

--- a/vignettes/uncertainty_params.Rmd
+++ b/vignettes/uncertainty_params.Rmd
@@ -147,14 +147,19 @@ final_size_data <- Map(
 # combine data
 final_size_data <- Reduce(x = final_size_data, f = rbind)
 
+# examine the data
+final_size_data
+```
+
+### Visualise uncertainty in final size
+
+```{r class.source = 'fold.hide'}
 # order age groups
 final_size_data$demo_grp <- factor(
   final_size_data$demo_grp,
   levels = contact_data$demography$age.group
 )
 ```
-
-### Visualise uncertainty in final size
 
 ```{r class.source = 'fold-hide', class.source = 'fold-hide', fig.cap="Estimated ranges of the final size of a hypothetical SIR epidemic in age groups of the U.K. population, when the $R_0$ is estimated to be 2.0, with a standard deviation around this estimate of 0.1. In this example, relatively low uncertainty in $R_0$ estimates can also lead to uncertainty in the estimated final size of the epidemic. Points represent means, while ranges extend between the 5th and 95th percentiles.", fig.width=5, fig.height=4}
 ggplot(final_size_data) +

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -275,7 +275,7 @@ In general terms, this could be interpreted as the rate of vaccine uptake, or as
 ### Getting data on within-group susceptibility differences {-}
 
 For within-group differences in susceptibility, such as due to immunisation, users could obtain this information from [age-specific vaccination uptake statistics from national governments (here, the UK)](https://coronavirus.data.gov.uk/details/vaccinations?areaType=nation%26areaName=England#card-vaccination_uptake_by_vaccination_date_age_demographics).
-When antibody response decays are known for an immunisation course [@iyer2020], more detailed statistics on the [percentage of people vaccinated (here, in the UK)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19latestinsights/vaccines) in the preceding few months only, may be more informative.
+When antibody response decays are known for an immunisation course [@iyer2020], more detailed statistics on the [percentage of people vaccinated in the preceding few months only (here, in the UK)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19latestinsights/vaccines), may be more informative.
 :::
 
 ```{r}

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -19,7 +19,7 @@ editor_options:
 Populations are often heterogeneous in their susceptibility to infection following exposure, independent of the exposure risk that comes from different social contact patterns. Such heterogeneity may be age-dependent and vary between age groups. It may also vary within age groups due to prior infection resulting in immunity or due to immunisation. Combinations of within- and between-group variation in susceptibility may also occur, and can be incorporated into final size calculations [@miller2012].
 
 ::: {.alert .alert-warning}
-**New to _finalsize_?** It may help to read the ["Basic usage"](finalsize.html) vignette first!
+**New to _finalsize_?** It may help to read the ["Get started"](finalsize.html) vignette first!
 :::
 
 ::: {.alert .alert-primary}
@@ -76,7 +76,7 @@ library(colorspace)
 
 This example uses social contact data from the POLYMOD project [@mossong2008] to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
 
-These data are handled just as in the ["Basic usage"](finalsize.html) vignette, and the code is not displayed here. This example also considers a disease with an $R_0$ of 2.0.
+These data are handled just as in the ["Get started"](finalsize.html) vignette, and the code is not displayed here. This example also considers a disease with an $R_0$ of 2.0.
 
 ```{r class.source = 'fold-hide'}
 # get UK polymod data

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -51,6 +51,16 @@ knitr::opts_chunk$set(
 )
 ```
 
+## Primer on heterogeneous susceptibility
+
+_Susceptibility to infection may be age-dependent and vary between demographic groups_, for example, between age groups due to [age-related impaired or dysregulated host immunity](https://www.jci.org/articles/view/144115).
+Susceptibility to infection in different demographic groups may be estimated from stratified attack rates or prevalence estimates from pathogens with similar immune responses (such as SARS, MERS, and Covid-19).
+
+For between-group differences, users may prefer to gather this information from stratified [prevalence estimates](https://www.nature.com/articles/s41467-021-21237-w/tables/2) over [observed incidence case rate](https://coronavirus.data.gov.uk/details/cases?areaType=nation%26areaName=England#card-case_rates_by_age_and_sex) due to [surveillance bias](https://www.bmj.com/content/374/bmj.n2126) towards registering more symptomatic individuals.
+
+Patterns of heterogeneous susceptibility may also be context dependent, and different patterns may be observed for the same infectious pathogen in different countries.
+For example, after the first peak of Covid-19 cases in 2020, [in Peru](https://www.thelancet.com/action/showFullTableHTML?isHtml=true&tableId=tbl0001&pii=S2589-5370%2821%2900081-X) prevalence had a uniform distribution across age groups, while [in the UK](https://www.nature.com/articles/s41467-021-21237-w/tables/2) prevalence across age groups was heterogeneous.
+
 ```{r setup, message=FALSE, warning=FALSE, class.source = 'fold-hide'}
 # load finalsize
 library(finalsize)
@@ -255,6 +265,14 @@ We also need to model the proportion of each age group that has been immunised, 
 This example model considers half of each age group to be in the immunised and non-immunised groups.
 
 In general terms, this could be interpreted as the rate of vaccine uptake, or as the effect of existing immunity from previous infection by a similar pathogen.
+
+::: {.alert .alert-secondary}
+
+### Getting data on within-group susceptibility differences {-}
+
+For within-group differences in susceptibility, such as due to immunisation, users could obtain this information from [age-specific vaccination uptake statistics from national governments (here, the UK)](https://coronavirus.data.gov.uk/details/vaccinations?areaType=nation%26areaName=England#card-vaccination_uptake_by_vaccination_date_age_demographics).
+When [antibody response decays](https://www.science.org/doi/full/10.1126/sciimmunol.abe0367) are known for an immunisation course, more detailed statistics on the [percentage of people vaccinated (here, in the UK)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19latestinsights/vaccines) in the preceding few months only, may be more informative.
+:::
 
 ```{r}
 # immunisation rate is uniform across age groups

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -93,7 +93,7 @@ contact_matrix <- t(contact_data$matrix)
 demography_vector <- contact_data$demography$population
 
 # scale the contact matrix so the largest eigenvalue is 1.0
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 
 # divide each row of the contact matrix by the corresponding demography
 contact_matrix <- contact_matrix / demography_vector

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -52,10 +52,14 @@ knitr::opts_chunk$set(
 ```
 
 ```{r setup, message=FALSE, warning=FALSE, class.source = 'fold-hide'}
+# load finalsize
 library(finalsize)
 
 # load necessary packages
-library(data.table)
+if (!require("socialmixr")) install.packages("socialmixr")
+if (!require("ggplot2")) install.packages("ggplot2")
+if (!require("colorspace")) install.packages("colorspace")
+
 library(ggplot2)
 library(colorspace)
 ```
@@ -98,7 +102,7 @@ r0 <- 2.0
 This example considers a scenario in which susceptibility to infection varies between age groups, but not within groups.
 In this example,  susceptibility to infection  increases with age.
 
-This can be modelled as a susceptibility matrix with higher values for the 40 -- 60 and 65+ age groups, and relatively lower values for other groups.
+This can be modelled as a susceptibility matrix with higher values for the 40 -- 64 and 65 and over age groups, and relatively lower values for other groups.
 
 ```{r}
 # susceptibility is higher for the old
@@ -253,7 +257,7 @@ This example model considers half of each age group to be in the immunised and n
 In general terms, this could be interpreted as the rate of vaccine uptake, or as the effect of existing immunity from previous infection by a similar pathogen.
 
 ```{r}
-# immunisation increases with age between 20% (infants) and 90% (65+)
+# immunisation rate is uniform across age groups
 immunisation_rate <- rep(0.5, n_demo_grps)
 
 # add a second column to p_susceptibility

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -16,7 +16,7 @@ editor_options:
   chunk_output_type: console
 ---
 
-Populations are often heterogeneous in their susceptibility to infection following exposure, independent of the exposure risk that comes from different social contact patterns. Such heterogeneity may be age-dependent and vary between age groups. It may also vary within age groups due to prior infection resulting in immunity or due to immunisation. Combinations of within- and between-group variation in susceptibility may also occur, and can be incorporated into final size calculations [ [@miller2012] ](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3506030/).
+Populations are often heterogeneous in their susceptibility to infection following exposure, independent of the exposure risk that comes from different social contact patterns. Such heterogeneity may be age-dependent and vary between age groups. It may also vary within age groups due to prior infection resulting in immunity or due to immunisation. Combinations of within- and between-group variation in susceptibility may also occur, and can be incorporated into final size calculations [@miller2012].
 
 ::: {.alert .alert-warning}
 **New to _finalsize_?** It may help to read the ["Basic usage"](finalsize.html) vignette first!
@@ -53,13 +53,11 @@ knitr::opts_chunk$set(
 
 ## Primer on heterogeneous susceptibility
 
-_Susceptibility to infection may be age-dependent and vary between demographic groups_, for example, between age groups due to [age-related impaired or dysregulated host immunity](https://www.jci.org/articles/view/144115).
-Susceptibility to infection in different demographic groups may be estimated from stratified attack rates or prevalence estimates from pathogens with similar immune responses (such as SARS, MERS, and Covid-19).
+A working definition of susceptibility is the probability of becoming infected on contact with an infectious person.
 
-For between-group differences, users may prefer to gather this information from stratified [prevalence estimates](https://www.nature.com/articles/s41467-021-21237-w/tables/2) over [observed incidence case rate](https://coronavirus.data.gov.uk/details/cases?areaType=nation%26areaName=England#card-case_rates_by_age_and_sex) due to [surveillance bias](https://www.bmj.com/content/374/bmj.n2126) towards registering more symptomatic individuals.
+Age-specific factors influencing the susceptibility of individuals include, but are not limited to, direct (immunological) susceptibility to infection upon exposure (e.g., due to natural susceptibility from previous infections, differences in vaccination status), and age-specific heterogeneous risk behaviour [@franco2022].
 
-Patterns of heterogeneous susceptibility may also be context dependent, and different patterns may be observed for the same infectious pathogen in different countries.
-For example, after the first peak of Covid-19 cases in 2020, [in Peru](https://www.thelancet.com/action/showFullTableHTML?isHtml=true&tableId=tbl0001&pii=S2589-5370%2821%2900081-X) prevalence had a uniform distribution across age groups, while [in the UK](https://www.nature.com/articles/s41467-021-21237-w/tables/2) prevalence across age groups was heterogeneous.
+For example, for SARS-CoV-2, children are less susceptible to it than adults. Decreased susceptibility could result from immune cross-protection from other coronaviruses [@huang2020], or from non-specific protection resulting from recent infection by other respiratory viruses [@cowling2012], which children experience more frequently than adults [@tsagarakis2018; @davies2020].
 
 ```{r setup, message=FALSE, warning=FALSE, class.source = 'fold-hide'}
 # load finalsize
@@ -76,7 +74,7 @@ library(colorspace)
 
 ## Getting $R_0$ and contact and demography data
 
-This example uses social contact data from the [POLYMOD](https://cordis.europa.eu/project/id/502084) project to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
+This example uses social contact data from the POLYMOD project [@mossong2008] to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
 
 These data are handled just as in the ["Basic usage"](finalsize.html) vignette, and the code is not displayed here. This example also considers a disease with an $R_0$ of 2.0.
 
@@ -271,7 +269,7 @@ In general terms, this could be interpreted as the rate of vaccine uptake, or as
 ### Getting data on within-group susceptibility differences {-}
 
 For within-group differences in susceptibility, such as due to immunisation, users could obtain this information from [age-specific vaccination uptake statistics from national governments (here, the UK)](https://coronavirus.data.gov.uk/details/vaccinations?areaType=nation%26areaName=England#card-vaccination_uptake_by_vaccination_date_age_demographics).
-When [antibody response decays](https://www.science.org/doi/full/10.1126/sciimmunol.abe0367) are known for an immunisation course, more detailed statistics on the [percentage of people vaccinated (here, in the UK)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19latestinsights/vaccines) in the preceding few months only, may be more informative.
+When antibody response decays are known for an immunisation course [@iyer2020], more detailed statistics on the [percentage of people vaccinated (here, in the UK)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19latestinsights/vaccines) in the preceding few months only, may be more informative.
 :::
 
 ```{r}

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -351,8 +351,8 @@ ggplot(final_size_immunised) +
     cols = vars(scenario),
     labeller = labeller(
       scenario = c(
-       heterogeneous = "Between groups only",
-        immunisation = "Within & between groups" 
+        heterogeneous = "Between groups only",
+        immunisation = "Within & between groups"
       )
     )
   ) +

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -162,6 +162,8 @@ final_size_uniform <- final_size(
 )
 ```
 
+Visualise the effect of modelling age-dependent susceptibility against uniform susceptibility for all age groups.
+
 ```{r}
 # assign scenario name and join data
 final_size_heterog$scenario <- "heterogeneous"
@@ -178,9 +180,10 @@ final_size_data$demo_grp <- factor(
   final_size_data$demo_grp,
   levels = contact_data$demography$age.group
 )
-```
 
-Visualise the effect of modelling age-dependent susceptibility against uniform susceptibility for all age groups.
+# examine the combined data
+final_size_data
+```
 
 ```{r class.source = 'fold-hide', fig.cap="Final sizes of epidemics in populations wherein susceptibility to the infection is either uniform (green), or heterogeneous (purple), with older individuals more susceptible to the infection.", fig.width=5, fig.height=4}
 ggplot(final_size_data) +
@@ -193,6 +196,9 @@ ggplot(final_size_data) +
     position = position_dodge(
       width = 0.75
     )
+  ) +
+  expand_limits(
+    x = c(0.5, length(unique(final_size_data$demo_grp)) + 0.5)
   ) +
   scale_fill_discrete_qualitative(
     palette = "Cold",
@@ -296,7 +302,11 @@ final_size_immunised <- final_size(
   susceptibility = susc_immunised,
   p_susceptibility = p_susc_immunised
 )
+```
 
+The effect of immunisation (or some other reduction in susceptibility) can be visualised by comparing the proportion of the immunised and un-immunised groups that are infected.
+
+```{r}
 # add scenario identifier
 final_size_immunised$scenario <- "immunisation"
 
@@ -310,9 +320,12 @@ final_size_immunised$demo_grp <- factor(
   final_size_immunised$demo_grp,
   levels = contact_data$demography$age.group
 )
+
+# examine the data
+final_size_immunised
 ```
 
-The effect of immunisation (or some other reduction in susceptibility) can be visualised by comparing the proportion of the immunised and un-immunised groups that are infected.
+Compare scenarios in which susceptibility is heterogeneous between groups, against the immunisation scenario in which susceptibility also varies within groups.
 
 ```{r fig.cap="Final size of an SIR epidemic with $R_0$ = 2.0, in a population wherein 50% of each age group is immunised against the infection. The immunisation is assumed to reduce the initial susceptibility of each age group by 25%. This leads to both within- and between-group heterogeneity in susceptibility. Vaccinating even 50% of each age group can substantially reduce the epidemic final size in comparison with a scenario in which there is no immunisation (grey). Note that the final sizes in this figure are all below 50%.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
 ggplot(final_size_immunised) +

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -347,6 +347,18 @@ ggplot(final_size_immunised) +
     col = "black",
     position = position_dodge()
   ) +
+  facet_grid(
+    cols = vars(scenario),
+    labeller = labeller(
+      scenario = c(
+       heterogeneous = "Between groups only",
+        immunisation = "Within & between groups" 
+      )
+    )
+  ) +
+  expand_limits(
+    x = c(0.5, length(unique(final_size_immunised$demo_grp)) + 0.5)
+  ) +
   scale_fill_discrete_qualitative(
     palette = "Dynamic",
     rev = TRUE,
@@ -356,8 +368,8 @@ ggplot(final_size_immunised) +
   ) +
   scale_colour_manual(
     values = "black",
-    name = NULL,
-    labels = "Susceptibility heterogeneous\nbetween groups,\nno immunisation"
+    name = "No immunisation",
+    labels = "Susceptibility homogeneous\nwithin groups"
   ) +
   scale_y_continuous(
     labels = scales::percent,
@@ -365,19 +377,27 @@ ggplot(final_size_immunised) +
   ) +
   theme_classic() +
   theme(
-    legend.position = "top",
+    legend.position = "bottom",
     legend.key.height = unit(2, "mm"),
     legend.title = ggtext::element_markdown(
       vjust = 1
+    ),
+    strip.background = element_blank(),
+    strip.text = element_text(
+      face = "bold",
+      size = 11
     )
   ) +
   guides(
     colour = guide_legend(
-      override.aes = list(fill = "lightgrey")
+      override.aes = list(fill = "lightgrey"),
+      title.position = "top",
+      order = 1
     ),
     fill = guide_legend(
       nrow = 2,
-      title.position = "top"
+      title.position = "top",
+      order = 2
     )
   ) +
   coord_cartesian(
@@ -386,6 +406,7 @@ ggplot(final_size_immunised) +
   labs(
     x = "Age group",
     y = "% Infected",
+    title = "Heterogeneous susceptibility",
     fill = "Immunisation\nscenario"
   )
 ```


### PR DESCRIPTION
This pull request:
1. Fixes #117 by replacing the development version installation instructions,
2. Fixes #118 by changing the order of `susceptibility` and `p_susceptibility` in the function call, and in documentation,
3. Fixes #122 by removing package installation step from 'Getting started' (vignettes/finalsize.Rmd),
4. Fixes #123 by checking for package installation before loading; removes `{data.table}` use,
5. Fixes #124 by changing the POLYMOD reference link to the PLOS Medicine paper,
6. Fixes #125 by changing age group notation in vignette text,
7. Fixes #127 by printing input and output to screen in the basic vignette.
8. Fixes #130 by adding a section on sources and patterns of heterogeneous susceptibility, and a box on getting data on these patterns

Additionally fixes #131 by using `max(Re(eigen(x)$values))` in the examples and documentation.