### PR TITLE
Correct examples, vignettes, tests to use real eigenvalues

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches:
+     - "*"
 
 name: R-CMD-check
 

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -148,7 +148,8 @@ final_size <- function(r0,
       ),
     "Error: contact matrix must have a maximum real eigenvalue of 1.0" =
       (
-        abs(max(eigen(contact_matrix * demography_vector)$values) - 1.0) < 1e-6
+        abs(max(Re(eigen(contact_matrix * demography_vector)$values) - 1.0)) <
+          1e-6
       ),
     "Error: control list names can only be: 'iterations', 'tolerance',
     'step_rate', 'adapt_step'" =

--- a/data-raw/polymod_uk.R
+++ b/data-raw/polymod_uk.R
@@ -14,7 +14,7 @@ contact_matrix <- t(polymod_uk$matrix)
 demography_vector <- polymod_uk$demography$population
 
 # scale contacts by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 polymod_uk <- list(

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -16,7 +16,7 @@ demography_vector <- contact_data$demography$population
 names(demography_vector) <- contact_data$demography$age.group
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 n_demo_grps <- length(demography_vector)

--- a/tests/testthat/test-messages.R
+++ b/tests/testthat/test-messages.R
@@ -13,7 +13,7 @@ contact_matrix <- t(contact_data$matrix)
 demography_vector <- contact_data$demography$population
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 p_susceptibility <- matrix(1, ncol = 1, nrow = 3)

--- a/tests/testthat/test-newton_solver.R
+++ b/tests/testthat/test-newton_solver.R
@@ -16,7 +16,7 @@ demography_vector <- contact_data$demography$population
 names(demography_vector) <- contact_data$demography$age.group
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 n_demo_grps <- length(demography_vector)

--- a/tests/testthat/test-solver_options.R
+++ b/tests/testthat/test-solver_options.R
@@ -16,7 +16,7 @@ demography_vector <- contact_data$demography$population
 names(demography_vector) <- contact_data$demography$age.group
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 n_demo_grps <- length(demography_vector)

--- a/tests/testthat/test-solver_speedups.R
+++ b/tests/testthat/test-solver_speedups.R
@@ -16,7 +16,7 @@ demography_vector <- contact_data$demography$population
 names(demography_vector) <- contact_data$demography$age.group
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 n_demo_grps <- length(demography_vector)

--- a/tests/testthat/test-statistical_correctness.R
+++ b/tests/testthat/test-statistical_correctness.R
@@ -202,7 +202,7 @@ contact_matrix <- t(contact_data$matrix)
 demography_vector <- contact_data$demography$population
 
 # scale by maximum real eigenvalue and divide by demography
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 contact_matrix <- contact_matrix / demography_vector
 
 r0 <- 2.0

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -102,7 +102,7 @@ demography_data <- contact_data$demography
 # scale the contact matrix so the largest eigenvalue is 1.0
 # this is to ensure that the overall epidemic dynamics correctly reflect
 # the assumed value of R0
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 
 # divide each row of the contact matrix by the corresponding demography
 # this reflects the assumption that each individual in group {j} make contacts

--- a/vignettes/uncertainty_params.Rmd
+++ b/vignettes/uncertainty_params.Rmd
@@ -82,7 +82,7 @@ contact_matrix <- t(contact_data$matrix)
 demography_vector <- contact_data$demography$population
 
 # scale the contact matrix so the largest eigenvalue is 1.0
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 
 # divide each row of the contact matrix by the corresponding demography
 contact_matrix <- contact_matrix / demography_vector

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -93,7 +93,7 @@ contact_matrix <- t(contact_data$matrix)
 demography_vector <- contact_data$demography$population
 
 # scale the contact matrix so the largest eigenvalue is 1.0
-contact_matrix <- contact_matrix / max(eigen(contact_matrix)$values)
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
 
 # divide each row of the contact matrix by the corresponding demography
 contact_matrix <- contact_matrix / demography_vector


### PR DESCRIPTION
Fixes #131 submitted by @erees. Corrects all cases in which the largest contact matrix eigenvalue is extracted to get the largest _real_ eigenvalue. This PR is being merged into #121 as scaling the contact matrix by the largest real eigenvalue is an important step that is covered in the vignettes.