### PR TITLE
Simplify "Get started" vignette

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,9 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.org/package=finalsize)
 <!-- badges: end -->
 
-_finalsize_ provides calculations for the final size of an epidemic in a population, which is the overall number of infected individuals, depending on a demographic distribution (e.g., age groups) and their contact patterns, accounting for different susceptibility to disease between groups (e.g., due to age-group specific immune responses) and within groups (e.g., due to immunisation programs).
+_finalsize_ is an R package to calculate the final size of a SIR epidemic in populations with heterogeneity in social contacts and infection susceptibility.
+
+_finalsize_ provides estimates for the total proportion of a population infected over the course of an epidemic, and can account for a demographic distribution (such as age groups) and demography-specific contact patterns, as well as for heterogeneous susceptibility to infection between groups (such as due to age-group specific immune responses) and within groups (such as due to immunisation programs).
 
 _finalsize_ implements methods outlined in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016.
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ coverage](https://codecov.io/gh/epiverse-trace/finalsize/branch/main/graph/badge
 status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.org/package=finalsize)
 <!-- badges: end -->
 
-*finalsize* provides calculations for the final size of an epidemic in a
-population, which is the overall number of infected individuals,
-depending on a demographic distribution (e.g., age groups) and their
-contact patterns, accounting for different susceptibility to disease
-between groups (e.g., due to age-group specific immune responses) and
-within groups (e.g., due to immunisation programs).
+*finalsize* is an R package to calculate the final size of a SIR
+epidemic in populations with heterogeneity in social contacts and
+infection susceptibility.
+
+*finalsize* provides estimates for the total proportion of a population
+infected over the course of an epidemic, and can account for a
+demographic distribution (such as age groups) and demography-specific
+contact patterns, as well as for heterogeneous susceptibility to
+infection between groups (such as due to age-group specific immune
+responses) and within groups (such as due to immunisation programs).
 
 *finalsize* implements methods outlined in Andreasen
 ([2011](#ref-andreasen2011)), Miller ([2012](#ref-miller2012)),

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -17,5 +17,6 @@ articles:
 - title: Package vignettes
   navbar: Package vignettes
   contents:
+  - varying_contacts
   - varying_susceptibility
   - uncertainty_params

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -27,9 +27,8 @@ An epidemic is underway. We want to know **how many individuals we would expect 
 ### What we have {-}
 
   1. An estimate of the infection's basic reproduction number $R_0$;
-  2. An estimate of the distribution of the population in different demographic groups (typically age groups);
-  3. An estimate of the contacts between individuals of different demographic groups; and
-  4. An estimate of the susceptibility of each demographic group to the infection.
+  2. An estimate of the population size;
+  3. An estimate of the susceptibility of the population to the infection.
 
 ### What we assume {-}
 
@@ -49,128 +48,63 @@ knitr::opts_chunk$set(
 ```{r}
 # load finalsize
 library(finalsize)
-
-# load necessary packages
-if (!require("socialmixr")) install.packages("socialmixr")
-if (!require("ggplot2")) install.packages("ggplot2")
-
-library(ggplot2)
 ```
 
 ## Defining a value for $R_0$
 
 A number of statistical methods can be used to estimate the $R_0$ of an epidemic in its early stages from available data. These are not discussed here, but some examples are given in the [_episoap_ package](https://epiverse-trace.github.io/episoap/articles/episoap.html).
 
-Instead, this example considers a infection with an $R_0$ of 2.0, similar to that which could potentially be observed for pandemic influenza.
+Instead, this example considers a infection with an $R_0$ of 1.5, similar to that which could potentially be observed for pandemic influenza.
 
 ```{r}
-# define r0 as 2.0
-r0 <- 2.0
+# define r0 as 1.5
+r0 <- 1.5
 ```
 
-## Getting and preparing contact and demography data
+## Getting population estimates
 
-This example uses social contact data from the POLYMOD project [@mossong2008] to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
-
-The contact data are divided into five age groups: 0 -- 4, 5 -- 17, 18 -- 39, 40 -- 64, and 65 and over, specified using the `age.limits` argument in `socialmixr::contact_matrix()`.
-The `symmetric = TRUE` argument to `socialmixr::contact_matrix()` returns a symmetric contact matrix, so that the contacts reported by group $\{i\}$ of individuals from group $\{j\}$ are the same as those reported by group $\{j\}$ of group $\{i\}$.
-
-The demographic data --- the number of individuals in each age group --- is also available through `socialmixr::contact_matrix()`.
+Population estimates at the country scale are relatively easy to get from trusted data aggregators such as [Our World in Data](https://ourworldindata.org/world-population-growth).
+More detailed breakdowns of population estimates at the sub-national scale may be available from their respective national governments.
+Here, we use an estimate for the U.K. population size of about 67 million.
 
 ```{r}
-# get UK polymod data
-polymod <- socialmixr::polymod
-contact_data <- socialmixr::contact_matrix(
-  polymod,
-  countries = "United Kingdom",
-  age.limits = c(0, 5, 18, 40, 65),
-  symmetric = TRUE
-)
+# get UK population size
+uk_pop <- 67 * 1e6
+```
 
-# view the elements of the contact data list
-# the contact matrix
-contact_data$matrix
+This initial example assumes uniform mixing, i.e., that all individuals in the population have a similar number of social contacts. This can be modelled in the form of a single-element contact matrix, which must be divided by the population size.
 
-# the demography data
-contact_data$demography
-
-# get the contact matrix and demography data
-contact_matrix <- t(contact_data$matrix)
-demography_vector <- contact_data$demography$population
-demography_data <- contact_data$demography
-
-# scale the contact matrix so the largest eigenvalue is 1.0
-# this is to ensure that the overall epidemic dynamics correctly reflect
-# the assumed value of R0
-contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
-
-# divide each row of the contact matrix by the corresponding demography
-# this reflects the assumption that each individual in group {j} make contacts
-# at random with individuals in group {i}
-contact_matrix <- contact_matrix / demography_vector
-
-n_demo_grps <- length(demography_vector)
+```{r}
+# prepare contact matrix
+contact_matrix <- matrix(1.0) / uk_pop
 ```
 
 ::: {.alert .alert-secondary}
+Social contacts are well known to be non-uniform, with age being a strong influence on how many contacts a person has, and moreover, on the ages of their contacts. A relatively simple example is that of children of school-going age, who typically have more social contacts than the elderly, and most of whose social contacts are with other schoolchildren.
 
-### Heterogeneous social mixing {-}
-
-The social contact data used in this example illustrate an important way in which populations may be heterogeneous: the various age groups can have substantially different patterns of social contacts, and hence different probabilities of acquiring and transmitting infection during an epidemic.
-
-The method implemented in _finalsize_ accounts for this heterogeneity. Other forms of population heterogeneity are covered in the ["Heterogeneous susceptibility"](varying_susceptibility.html) vignette.
+The ["Modelling heterogeneous contacts"](varying_contacts.Rmd) vignette explores how this can be incorporated into final epidemic size calculations using _finalsize_.
 :::
 
-## Population susceptibility
+## Modelling population susceptibility
 
-As a starting scenario, consider a novel pathogen where all age groups have a similar, high susceptibility to infection. This means it is assumed that all individuals fall into a single category: fully susceptible.
-
-Full uniform susceptibility can be modelled as a matrix with values of 1.0, with as many rows as there are demographic groups. The matrix has a single column, representing the single susceptibility group to which all individuals belong.
+In this initial example, the population is assumed to be fully susceptible to infection. This is modelled in the form of a matrix with a single element, called `susceptibility`.
 
 ```{r}
-# all individuals are equally and highly susceptible
-n_susc_groups <- 1L
-susc_guess <- 1.0
+# all individuals are fully susceptible
+susceptibility <- matrix(1.0)
 ```
 
-```{r}
-susc_uniform <- matrix(
-  data = susc_guess,
-  nrow = n_demo_grps,
-  ncol = n_susc_groups
-)
-```
-
-Final size calculations also need to know the proportion of each demographic group $\{i\}$ that falls into the susceptibility group $\{j\}$. This distribution of age groups into susceptibility groups can be represented by the demography-susceptibility distribution matrix.
-
-Since all individuals in each age group have the same susceptibility, there is no variation within age groups. Consequently, all individuals in each age group are assumed to be fully susceptible. This can be represented as a single-column matrix, with as many rows as age groups, and as many columns as susceptibility groups.
-
-In this example, the matrix `p_susc_uniform` has `r n_demo_grps` rows, one for each age group, and only one column, for the single high susceptibility group that holds all individuals.
+Since all individuals are fully susceptible, the break-up of the population into susceptibility groups can be represented as another single-element matrix, called `p_susceptibility`.
 
 ```{r}
-p_susc_uniform <- matrix(
-  data = 1.0,
-  nrow = n_demo_grps,
-  ncol = n_susc_groups
-)
+# all individuals are in the single, high-susceptibility group
+p_susceptibility <- matrix(1.0)
 ```
 
 ::: {.alert .alert-secondary}
+Susceptibility to infection is well known to vary due to a number of factors, including age, prior exposure to the pathogen, or immunisation due to a vaccination campaign.
 
-#### Why susceptibility and p_susceptibility are matrices {-}
-
-This example models susceptibility (`susc_uniform`) and the demography-in-susceptibility (`p_susc_uniform`) as matrices rather than vectors. This is because a single susceptibility group is a special case of the general final size equation.
-
-_finalsize_ supports multiple susceptibility groups (this will be covered later), and these are more easily represented as a matrix, the _susceptibility matrix_.
-
-Each element $\{i, j\}$ in this matrix represents the susceptibility of individuals in demographic group $\{i\}$, and susceptibility group $\{j\}$.
-
-In this example, all individuals are equally susceptible to infection, and thus the susceptibility matrix (`susc_uniform`) has only a single column with identical values.
-
-Consequently, the demography-susceptibility distribution matrix (`p_susc_uniform`) has the same dimensions, and all of its values are 1.0.
-
-See the ["Heterogeneous susceptibility"](varying_susceptibility.html) example for more on cases where susceptibility varies within age groups.
-
+The ["Modelling heterogeneous susceptibility"](varying_susceptibility.Rmd) vignette explores how variation in susceptibility within and between demographic groups can be incorporated into final epidemic size calculations using _finalsize_.
 :::
 
 ## Running `final_size`
@@ -182,105 +116,17 @@ The final size of the epidemic in the population can then be calculated using th
 final_size_data <- final_size(
   r0 = r0,
   contact_matrix = contact_matrix,
-  demography_vector = demography_vector,
-  susceptibility = susc_uniform,
-  p_susceptibility = p_susc_uniform
+  demography_vector = uk_pop,
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility
 )
 
 # view the output data frame
 final_size_data
 ```
 
-### Visualise final sizes
+This is the final epidemic size without accounting for heterogeneity in social contacts by age or other factors, and without accounting for variation in susceptibility to infection between or within demographic groups.
 
-```{r class.source = 'fold.hide'}
-# order demographic groups as factors
-final_size_data$demo_grp <- factor(
-  final_size_data$demo_grp,
-  levels = demography_data$age.group
-)
-```
-
-```{r fig.cap ="Final size of an SIR epidemic in each age group. The final size is the cumulative number of infections in each age group over the course of the epidemic, expressed as a proportion of the respective age group.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
-# plot data
-ggplot(final_size_data) +
-  geom_col(
-    aes(
-      demo_grp, p_infected
-    ),
-    colour = "black", fill = "grey"
-  ) +
-  scale_y_continuous(
-    labels = scales::percent,
-    limits = c(0, 1)
-  ) +
-  expand_limits(
-    x = c(0.5, nrow(final_size_data) + 0.5)
-  ) +
-  theme_classic() +
-  coord_cartesian(
-    expand = FALSE
-  ) +
-  labs(
-    x = "Age group",
-    y = "% Infected"
-  )
-```
-
-### Final size proportions to counts
-
-`finalsize` returns the _proportion_ of each age (and susceptibility) group infected in an epidemic outbreak. The final _counts_ of individuals infected can be visualised as well, by multiplying the final proportion of each age group infected with the total number of individuals in that group.
-
-The example below show how this can be done.
-
-```{r}
-# prepare demography data
-demography_data <- contact_data$demography
-
-# merge final size counts with demography vector
-final_size_data <- merge(
-  final_size_data,
-  demography_data,
-  by.x = "demo_grp",
-  by.y = "age.group"
-)
-
-# reset age group order
-final_size_data$demo_grp <- factor(
-  final_size_data$demo_grp,
-  levels = contact_data$demography$age.group
-)
-
-# multiply counts with proportion infected
-final_size_data$n_infected <- final_size_data$p_infected *
-  final_size_data$population
-```
-
-```{r fig.cap="Final size of an epidemic outbreak in a population, for different values of infection $R_0$. Converting the final size proportions in each age group to counts shows that individuals aged 18 -- 64 make up the bulk of cases in this scenario. This may be attributed to this being both the largest age range in the analysis (more years in this range than any other), and because more people fall into this wide range than others. Contrast this figure with the one above, in which similar _proportions_ of each age group are infected.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
-ggplot(final_size_data) +
-  geom_col(
-    aes(
-      x = demo_grp, y = n_infected
-    ),
-    fill = "grey", col = "black"
-  ) +
-  expand_limits(
-    x = c(0.5, nrow(final_size_data) + 0.5)
-  ) +
-  scale_y_continuous(
-    labels = scales::comma_format(
-      scale = 1e-6, suffix = "M"
-    ),
-    limits = c(0, 15e6)
-  ) +
-  theme_classic() +
-  coord_cartesian(
-    expand = FALSE
-  ) +
-  labs(
-    x = "Age group",
-    y = "Number infected (millions)"
-  )
-```
+This value, of about `r scales::percent(round(final_size_data$p_infected, 2))` of the population infected, is easily converted to a count, and suggests that about `r scales::comma(final_size_data$p_infected * uk_pop, scale = 1e-6, suffix = " million")` people would be infected over the course of this epidemic.
 
 ## References

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -80,7 +80,7 @@ contact_matrix <- matrix(1.0) / uk_pop
 ```
 
 ::: {.alert .alert-secondary}
-Social contacts are well known to be non-uniform, with age being a strong influence on how many contacts a person has, and moreover, on the ages of their contacts. A relatively simple example is that of children of school-going age, who typically have more social contacts than the elderly, and most of whose social contacts are with other schoolchildren.
+Social contacts are well known to be non-uniform, with age being a strong influence on how many contacts a person has and, moreover, on the ages of their contacts. A relatively simple example is that of children of school-going age, who typically have more social contacts than the elderly, and most of whose social contacts are with other schoolchildren.
 
 The ["Modelling heterogeneous contacts"](varying_contacts.Rmd) vignette explores how this can be incorporated into final epidemic size calculations using _finalsize_.
 :::

--- a/vignettes/uncertainty_params.Rmd
+++ b/vignettes/uncertainty_params.Rmd
@@ -19,7 +19,7 @@ editor_options:
 Epidemic final size calculations are sensitive to input data such as the $R_0$ of the infection. Such values can often be uncertain in the early stages of an outbreak. This uncertainty can be included in final size calculations by running `final_size()` for values drawn from a distribution, and summarising the outcomes.
 
 ::: {.alert .alert-warning}
-**New to _finalsize_?** It may help to read the ["Get started"](finalsize.html) or ["Modelling heterogeneous susceptibility"](varying_susceptibility.Rmd) vignettes first!
+**New to _finalsize_?** It may help to read the ["Get started"](finalsize.html), ["Modelling heterogeneous contacts"](varying_contacts.html), or ["Modelling heterogeneous susceptibility"](varying_susceptibility.Rmd) vignettes first!
 :::
 
 ::: {.alert .alert-primary}
@@ -65,7 +65,7 @@ library(ggplot2)
 
 This example uses social contact data from the [POLYMOD](https://cordis.europa.eu/project/id/502084) project to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
 
-These data are handled just as in the ["Get started"](finalsize.html) vignette. This example also considers an infection with an $R_0$ of 2.0.
+These data are handled just as in the ["Get started"](finalsize.html) vignette. This example also considers an infection with an $R_0$ of 1.5.
 
 ```{r}
 # get UK polymod data
@@ -91,8 +91,8 @@ n_demo_grps <- length(demography_vector)
 ```
 
 ```{r}
-# mean R0 is 2.0
-r0_mean <- 2.0
+# mean R0 is 1.5
+r0_mean <- 1.5
 ```
 
 For simplicity, this example considers a scenario in which susceptibility to infection does not vary.
@@ -115,7 +115,7 @@ The basic reproduction number $R_0$ of an infection might be uncertain in the ea
 
 This example assumes that the $R_0$ estimate, and the uncertainty around that estimate, is provided as the mean and standard deviation of a normal distribution.
 
-This example considers a normal distribution $N(\mu = 2.0, \sigma = 0.1)$, for an $R_0$ of 2.0. We can draw 1,000 $R_0$ samples from this distribution and run `final_size()` on the contact data and demography data for each sample.
+This example considers a normal distribution $N(\mu = 1.5, \sigma = 0.1)$, for an $R_0$ of 1.5. We can draw 1,000 $R_0$ samples from this distribution and run `final_size()` on the contact data and demography data for each sample.
 
 This is quick, as `finalsize` is an Rcpp package with a C++ backend.
 
@@ -161,7 +161,7 @@ final_size_data$demo_grp <- factor(
 )
 ```
 
-```{r class.source = 'fold-hide', class.source = 'fold-hide', fig.cap="Estimated ranges of the final size of a hypothetical SIR epidemic in age groups of the U.K. population, when the $R_0$ is estimated to be 2.0, with a standard deviation around this estimate of 0.1. In this example, relatively low uncertainty in $R_0$ estimates can also lead to uncertainty in the estimated final size of the epidemic. Points represent means, while ranges extend between the 5th and 95th percentiles.", fig.width=5, fig.height=4}
+```{r class.source = 'fold-hide', class.source = 'fold-hide', fig.cap="Estimated ranges of the final size of a hypothetical SIR epidemic in age groups of the U.K. population, when the $R_0$ is estimated to be 1.5, with a standard deviation around this estimate of 0.1. In this example, relatively low uncertainty in $R_0$ estimates can also lead to uncertainty in the estimated final size of the epidemic. Points represent means, while ranges extend between the 5th and 95th percentiles.", fig.width=5, fig.height=4}
 ggplot(final_size_data) +
   stat_summary(
     aes(

--- a/vignettes/varying_contacts.Rmd
+++ b/vignettes/varying_contacts.Rmd
@@ -1,0 +1,289 @@
+---
+title: "Modelling heterogeneous social contacts"
+output:
+  bookdown::html_vignette2:
+    fig_caption: yes
+    code_folding: show
+pkgdown:
+  as_is: true
+bibliography: references.bib
+link-citations: true
+vignette: >
+  %\VignetteIndexEntry{Modelling heterogeneous social contacts}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+Populations are often heterogeneous in their social contact patterns. Such heterogeneity is often age-dependent and varies between age groups, and can strongly influence epidemic dynamics if the outbreak primarily circulates in a particular age group. This heterogeneity can be incorporated into final size calculations [@miller2012], and is implemented in _finalsize_.
+
+::: {.alert .alert-warning}
+**New to _finalsize_?** It may help to read the ["Get started"](finalsize.html) vignette first!
+:::
+
+::: {.alert .alert-primary}
+## Use case {-}
+
+There is substantial **heterogeneity in contact patterns** in a population. We want to know how this heterogeneity could affect the final size of the epidemic.
+:::
+
+::: {.alert .alert-secondary}
+### What we have {-}
+
+  1. An estimate of the infection's basic reproduction number $R_0$;
+  2. An estimate of the distribution of the population in different demographic groups (typically age groups);
+  3. An estimate of the contacts between individuals of different demographic groups; and
+  4. An estimate of the susceptibility of each demographic group to the infection.
+
+### What we assume {-}
+
+  1. That the infection dynamics can be captured using a Susceptible-Infectious-Recovered (SIR) or Susceptible-Exposed-Infectious-Recovered (SEIR) model, where individuals who have been infected acquire immunity against subsequent infection, at least for the remaining duration of the epidemic.
+:::
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  message = FALSE,
+  warning = FALSE,
+  dpi = 300
+)
+```
+
+```{r}
+# load finalsize
+library(finalsize)
+
+# load necessary packages
+if (!require("socialmixr")) install.packages("socialmixr")
+if (!require("ggplot2")) install.packages("ggplot2")
+
+library(ggplot2)
+```
+
+## Defining a value for $R_0$
+
+A number of statistical methods can be used to estimate the $R_0$ of an epidemic in its early stages from available data. These are not discussed here, but some examples are given in the [_episoap_ package](https://epiverse-trace.github.io/episoap/articles/episoap.html).
+
+Instead, this example considers a infection with an $R_0$ of 1.5, similar to that which could potentially be observed for pandemic influenza.
+
+```{r}
+# define r0 as 1.5
+r0 <- 1.5
+```
+
+::: {.alert .alert-secondary}
+
+### Heterogeneous social mixing {-}
+
+The social contact data used in this example illustrate an important way in which populations may be heterogeneous: the various age groups can have substantially different patterns of social contacts, and hence different probabilities of acquiring and transmitting infection during an epidemic.
+
+The method implemented in _finalsize_ accounts for this heterogeneity. Other forms of population heterogeneity are covered in the ["Heterogeneous susceptibility"](varying_susceptibility.html) vignette.
+:::
+
+## Getting and preparing contact and demography data
+
+This example uses social contact data from the POLYMOD project [@mossong2008] to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
+
+The contact data are divided into five age groups: 0 -- 4, 5 -- 17, 18 -- 39, 40 -- 64, and 65 and over, specified using the `age.limits` argument in `socialmixr::contact_matrix()`.
+The `symmetric = TRUE` argument to `socialmixr::contact_matrix()` returns a symmetric contact matrix, so that the contacts reported by group $\{i\}$ of individuals from group $\{j\}$ are the same as those reported by group $\{j\}$ of group $\{i\}$.
+
+The demographic data --- the number of individuals in each age group --- is also available through `socialmixr::contact_matrix()`.
+
+```{r}
+# get UK polymod data
+polymod <- socialmixr::polymod
+contact_data <- socialmixr::contact_matrix(
+  polymod,
+  countries = "United Kingdom",
+  age.limits = c(0, 5, 18, 40, 65),
+  symmetric = TRUE
+)
+
+# view the elements of the contact data list
+# the contact matrix
+contact_data$matrix
+
+# the demography data
+contact_data$demography
+
+# get the contact matrix and demography data
+contact_matrix <- t(contact_data$matrix)
+demography_vector <- contact_data$demography$population
+demography_data <- contact_data$demography
+
+# scale the contact matrix so the largest eigenvalue is 1.0
+# this is to ensure that the overall epidemic dynamics correctly reflect
+# the assumed value of R0
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
+
+# divide each row of the contact matrix by the corresponding demography
+# this reflects the assumption that each individual in group {j} make contacts
+# at random with individuals in group {i}
+contact_matrix <- contact_matrix / demography_vector
+
+n_demo_grps <- length(demography_vector)
+```
+
+## Population susceptibility
+
+As a starting scenario, consider a novel pathogen where all age groups have a similar, high susceptibility to infection. This means it is assumed that all individuals fall into a single category: fully susceptible.
+
+Full uniform susceptibility can be modelled as a matrix with values of 1.0, with as many rows as there are demographic groups. The matrix has a single column, representing the single susceptibility group to which all individuals belong.
+
+```{r}
+# all individuals are equally and highly susceptible
+n_susc_groups <- 1L
+susc_guess <- 1.0
+```
+
+```{r}
+susc_uniform <- matrix(
+  data = susc_guess,
+  nrow = n_demo_grps,
+  ncol = n_susc_groups
+)
+```
+
+Final size calculations also need to know the proportion of each demographic group $\{i\}$ that falls into the susceptibility group $\{j\}$. This distribution of age groups into susceptibility groups can be represented by the demography-susceptibility distribution matrix.
+
+Since all individuals in each age group have the same susceptibility, there is no variation within age groups. Consequently, all individuals in each age group are assumed to be fully susceptible. This can be represented as a single-column matrix, with as many rows as age groups, and as many columns as susceptibility groups.
+
+In this example, the matrix `p_susc_uniform` has `r n_demo_grps` rows, one for each age group, and only one column, for the single high susceptibility group that holds all individuals.
+
+```{r}
+p_susc_uniform <- matrix(
+  data = 1.0,
+  nrow = n_demo_grps,
+  ncol = n_susc_groups
+)
+```
+
+::: {.alert .alert-secondary}
+
+#### Why susceptibility and p_susceptibility are matrices {-}
+
+This example models susceptibility (`susc_uniform`) and the demography-in-susceptibility (`p_susc_uniform`) as matrices rather than vectors. This is because a single susceptibility group is a special case of the general final size equation.
+
+_finalsize_ supports multiple susceptibility groups (this will be covered later), and these are more easily represented as a matrix, the _susceptibility matrix_.
+
+Each element $\{i, j\}$ in this matrix represents the susceptibility of individuals in demographic group $\{i\}$, and susceptibility group $\{j\}$.
+
+In this example, all individuals are equally susceptible to infection, and thus the susceptibility matrix (`susc_uniform`) has only a single column with identical values.
+
+Consequently, the demography-susceptibility distribution matrix (`p_susc_uniform`) has the same dimensions, and all of its values are 1.0.
+
+See the ["Heterogeneous susceptibility"](varying_susceptibility.html) example for more on cases where susceptibility varies within age groups.
+
+:::
+
+## Running `final_size`
+
+The final size of the epidemic in the population can then be calculated using the only function in the package, `final_size()`. This example allows the function to fall back on the default options for the arguments `solver` (`"iterative"`) and `control` (an empty list).
+
+```{r}
+# calculate final size
+final_size_data <- final_size(
+  r0 = r0,
+  contact_matrix = contact_matrix,
+  demography_vector = demography_vector,
+  susceptibility = susc_uniform,
+  p_susceptibility = p_susc_uniform
+)
+
+# view the output data frame
+final_size_data
+```
+
+### Visualise final sizes
+
+```{r class.source = 'fold.hide'}
+# order demographic groups as factors
+final_size_data$demo_grp <- factor(
+  final_size_data$demo_grp,
+  levels = demography_data$age.group
+)
+```
+
+```{r fig.cap ="Final size of an SIR epidemic in each age group. The final size is the cumulative number of infections in each age group over the course of the epidemic, expressed as a proportion of the respective age group.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
+# plot data
+ggplot(final_size_data) +
+  geom_col(
+    aes(
+      demo_grp, p_infected
+    ),
+    colour = "black", fill = "grey"
+  ) +
+  scale_y_continuous(
+    labels = scales::percent,
+    limits = c(0, 1)
+  ) +
+  expand_limits(
+    x = c(0.5, nrow(final_size_data) + 0.5)
+  ) +
+  theme_classic() +
+  coord_cartesian(
+    expand = FALSE
+  ) +
+  labs(
+    x = "Age group",
+    y = "% Infected"
+  )
+```
+
+### Final size proportions to counts
+
+`finalsize` returns the _proportion_ of each age (and susceptibility) group infected in an epidemic outbreak. The final _counts_ of individuals infected can be visualised as well, by multiplying the final proportion of each age group infected with the total number of individuals in that group.
+
+The example below show how this can be done.
+
+```{r}
+# prepare demography data
+demography_data <- contact_data$demography
+
+# merge final size counts with demography vector
+final_size_data <- merge(
+  final_size_data,
+  demography_data,
+  by.x = "demo_grp",
+  by.y = "age.group"
+)
+
+# reset age group order
+final_size_data$demo_grp <- factor(
+  final_size_data$demo_grp,
+  levels = contact_data$demography$age.group
+)
+
+# multiply counts with proportion infected
+final_size_data$n_infected <- final_size_data$p_infected *
+  final_size_data$population
+```
+
+```{r fig.cap="Final size of an epidemic outbreak in a population, for different values of infection $R_0$. Converting the final size proportions in each age group to counts shows that individuals aged 18 -- 64 make up the bulk of cases in this scenario. This may be attributed to this being both the largest age range in the analysis (more years in this range than any other), and because more people fall into this wide range than others. Contrast this figure with the one above, in which similar _proportions_ of each age group are infected.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
+ggplot(final_size_data) +
+  geom_col(
+    aes(
+      x = demo_grp, y = n_infected
+    ),
+    fill = "grey", col = "black"
+  ) +
+  expand_limits(
+    x = c(0.5, nrow(final_size_data) + 0.5)
+  ) +
+  scale_y_continuous(
+    labels = scales::comma_format(
+      scale = 1e-6, suffix = "M"
+    ),
+    limits = c(0, 15e6)
+  ) +
+  theme_classic() +
+  coord_cartesian(
+    expand = FALSE
+  ) +
+  labs(
+    x = "Age group",
+    y = "Number infected (millions)"
+  )
+```
+
+## References

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -76,7 +76,7 @@ library(colorspace)
 
 This example uses social contact data from the POLYMOD project [@mossong2008] to estimate the final size of an epidemic in the U.K. These data are provided with the `socialmixr` package.
 
-These data are handled just as in the ["Get started"](finalsize.html) vignette, and the code is not displayed here. This example also considers a disease with an $R_0$ of 2.0.
+These data are handled just as in the ["Get started"](finalsize.html) vignette, and the code is not displayed here. This example also considers a disease with an $R_0$ of 1.5.
 
 ```{r class.source = 'fold-hide'}
 # get UK polymod data
@@ -102,7 +102,7 @@ n_demo_grps <- length(demography_vector)
 ```
 
 ```{r class.source = 'fold-hide'}
-r0 <- 2.0
+r0 <- 1.5
 ```
 
 ## Susceptibility variation between age groups
@@ -115,7 +115,7 @@ This can be modelled as a susceptibility matrix with higher values for the 40 --
 ```{r}
 # susceptibility is higher for the old
 susc_variable <- matrix(
-  data = c(0.2, 0.5, 0.6, 0.9, 1.0)
+  data = c(0.75, 0.8, 0.85, 0.9, 1.0)
 )
 n_susc_groups <- 1L
 ```
@@ -327,7 +327,7 @@ final_size_immunised
 
 Compare scenarios in which susceptibility is heterogeneous between groups, against the immunisation scenario in which susceptibility also varies within groups.
 
-```{r fig.cap="Final size of an SIR epidemic with $R_0$ = 2.0, in a population wherein 50% of each age group is immunised against the infection. The immunisation is assumed to reduce the initial susceptibility of each age group by 25%. This leads to both within- and between-group heterogeneity in susceptibility. Vaccinating even 50% of each age group can substantially reduce the epidemic final size in comparison with a scenario in which there is no immunisation (grey). Note that the final sizes in this figure are all below 50%.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
+```{r fig.cap="Final size of an SIR epidemic with $R_0$ = 1.5, in a population wherein 50% of each age group is immunised against the infection. The immunisation is assumed to reduce the initial susceptibility of each age group by 25%. This leads to both within- and between-group heterogeneity in susceptibility. Vaccinating even 50% of each age group can substantially reduce the epidemic final size in comparison with a scenario in which there is no immunisation (grey). Note that the final sizes in this figure are all below 50%.", fig.width=5, fig.height=4, class.source = 'fold-hide'}
 ggplot(final_size_immunised) +
   geom_col(
     data = final_size_heterog,
@@ -409,6 +409,38 @@ ggplot(final_size_immunised) +
     title = "Heterogeneous susceptibility",
     fill = "Immunisation\nscenario"
   )
+```
+
+## Heterogeneous susceptibility without social contact heterogeneity
+
+_finalsize_ can also account for heterogeneous susceptibilities without having to include heterogeneity in social contact patterns. This may be useful when calculating the final epidemic size without a good estimate of social contact patterns available.
+
+This is done in a similar way as in the ["Get started"](finalsize.html) vignette, but with `susceptibility` and `p_susceptibility` passed as $N$-column matrices, referring to the susceptibilities of the $N$ susceptibility groups, and the proportions of the population that are in these groups, respectively.
+
+This example considers pandemic influenza with an $R_0$ of 1.5, affecting the U.K population of 67 million which is assumed to mix uniformly, but which has two distinct susceptibility groups, with susceptibility values of 1.0 (70% of the population), and 0.7 (30% of the population).
+
+```{r}
+# define r0
+r0 <- 1.5
+
+# define UK population size and prepare contact matrix
+uk_pop <- 67 * 1e6
+contact_matrix <- matrix(1.0) / uk_pop
+
+# define susceptibility matrix
+susceptibility <- matrix(c(1.0, 0.7), nrow = 1, ncol = 2)
+
+# define p_susceptibility
+p_susceptibility <- matrix(c(0.7, 0.3), nrow = 1, ncol = 2)
+
+# running final_size()
+final_size(
+  r0 = r0,
+  demography_vector = uk_pop,
+  contact_matrix = contact_matrix,
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility
+)
 ```
 
 ## References

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -19,7 +19,7 @@ editor_options:
 Populations are often heterogeneous in their susceptibility to infection following exposure, independent of the exposure risk that comes from different social contact patterns. Such heterogeneity may be age-dependent and vary between age groups. It may also vary within age groups due to prior infection resulting in immunity or due to immunisation. Combinations of within- and between-group variation in susceptibility may also occur, and can be incorporated into final size calculations [@miller2012].
 
 ::: {.alert .alert-warning}
-**New to _finalsize_?** It may help to read the ["Get started"](finalsize.html) vignette first!
+**New to _finalsize_?** It may help to read the ["Get started"](finalsize.html) and ["Modelling heterogeneous contacts"](varying_contacts.html) vignettes first!
 :::
 
 ::: {.alert .alert-primary}


### PR DESCRIPTION
This PR fixes #142 and also simplifies the "Get started" vignette (`finalsize.Rmd`), to show an example _without_ age-stratified social contact patterns, and with a single population-wide susceptibility to infection.

This is likely to provide an easier entry point for users than the previous contents, which are now moved to their own vignette, "Modelling heterogeneous social contacts".

This PR also:
1. Uses an $R_0$ value of 1.5 (pandemic influenza) in all cases,
2. Adds links to earlier vignettes where required,
3. Adds an example showing how heterogeneous susceptibility can be modelled without also including heterogeneous social contacts.
4. Fixes #116 again by editing the Readme.