### PR TITLE
Render dev version of website

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -34,13 +34,16 @@ _finalsize_ relies on [Eigen](https://gitlab.com/libeigen/eigen) via [RcppEigen]
 
 ## Installation
 
-The package can be installed using
+The package can be installed from CRAN using
 
 ```r
 install.packages("finalsize")
 ```
 
+### Development version
+
 The current development version of _finalsize_ can be installed from [Github](https://github.com/epiverse-trace/finalsize) using the `remotes` package.
+The development version documentation can be found [here](https://epiverse-trace.github.io/finalsize/dev/).
 
 ```r
 # check whether {remotes} is installed

--- a/README.md
+++ b/README.md
@@ -43,15 +43,18 @@ at the London School of Hygiene and Tropical Medicine as part of the
 
 ## Installation
 
-The package can be installed using
+The package can be installed from CRAN using
 
 ``` r
 install.packages("finalsize")
 ```
 
+### Development version
+
 The current development version of *finalsize* can be installed from
 [Github](https://github.com/epiverse-trace/finalsize) using the
-`remotes` package.
+`remotes` package. The development version documentation can be found
+[here](https://epiverse-trace.github.io/finalsize/dev/).
 
 ``` r
 # check whether {remotes} is installed

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,6 +13,8 @@ template:
         gtag('js', new Date());
         gtag('config', 'G-XZ471458FQ');
       </script>
+development:
+  mode: auto
 articles:
 - title: Package vignettes
   navbar: Package vignettes


### PR DESCRIPTION
This PR aims to fix #147 by rendering the development version of the website and linking it from the Readme.