### PR TITLE
Ignore vignettes for repo langs stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vignettes/* linguist-documentation


### PR DESCRIPTION
Ignore the vignettes/ directory when calculating repository language statistics. Prevents over-representation of languages used to write the vignettes (here, R), as well as inclusion of languages that do not influence the package code (here, LaTeX, from the references stored as a .bib file).