### PR TITLE
Miscellaneous fixes and additions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,11 +6,11 @@ This outlines how to propose a change to finalsize.
 
 If you want to make a change, it's a good idea to first file an issue and make sure someone from the team agrees that it’s needed.
 If you’ve found a bug, please file an issue that illustrates the bug with a minimal 
-[reprex](https://www.tidyverse.org/help/#reprex) (this will also help you write a unit test, if needed). See [bug report template](../.github/ISSUE_TEMPLATE/bug_report.md). If you have a feature request see [feature request](../.github/ISSUE_TEMPLATE/feature_request.md).
+[reprex](https://www.tidyverse.org/help/#reprex) (this will also help you write a unit test, if needed). See [bug report template](https://github.com/epiverse-trace/finalsize/issues/new?assignees=&labels=&template=bug_report.md&title=). If you have a feature request see [feature request](https://github.com/epiverse-trace/finalsize/issues/new?assignees=&labels=&template=feature_request.md&title=).
 
 ### Pull request process
 
-See [pull request template](../.github/PULL_REQUEST_TEMPLATE/pull_request_template.md)
+See [pull request template](https://github.com/epiverse-trace/finalsize/blob/main/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md)
 
 *   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("epiverse-trace/finalsize", fork = TRUE)`.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,6 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![R-CMD-check](https://github.com/epiverse-trace/finalsize/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/finalsize/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/epiverse-trace/finalsize/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/finalsize?branch=main)
 [![CRAN status](https://www.r-pkg.org/badges/version/finalsize)](https://CRAN.R-project.org/package=finalsize)
@@ -30,7 +31,7 @@ _finalsize_ implements methods outlined in @andreasen2011, @miller2012, @kuchars
 
 _finalsize_ can help provide rough estimates of the effectiveness of pharmaceutical interventions in the form of immunisation programmes, or the effect of naturally acquired immunity through previous infection (see the vignette).
 
-_finalsize_ relies on [Eigen](https://gitlab.com/libeigen/eigen) via [RcppEigen](https://github.com/RcppCore/RcppEigen) for fast matrix algebra, and is developed at the [Centre for the Mathematical Modelling of Infectious Diseases](https://www.lshtm.ac.uk/research/centres/centre-mathematical-modelling-infectious-diseases) at the London School of Hygiene and Tropical Medicine as part of the [Epiverse Initiative](https://data.org/initiatives/epiverse/).
+_finalsize_ relies on [Eigen](https://gitlab.com/libeigen/eigen) via [RcppEigen](https://github.com/RcppCore/RcppEigen) for fast matrix algebra, and is developed at the [Centre for the Mathematical Modelling of Infectious Diseases](https://www.lshtm.ac.uk/research/centres/centre-mathematical-modelling-infectious-diseases) at the London School of Hygiene and Tropical Medicine as part of the [Epiverse-TRACE](https://data.org/initiatives/epiverse/).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 [![License:
 MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Project Status: Active – The project has reached a stable, usable
+state and is being actively
+developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![R-CMD-check](https://github.com/epiverse-trace/finalsize/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/finalsize/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
 coverage](https://codecov.io/gh/epiverse-trace/finalsize/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/finalsize?branch=main)
@@ -39,7 +42,7 @@ algebra, and is developed at the [Centre for the Mathematical Modelling
 of Infectious
 Diseases](https://www.lshtm.ac.uk/research/centres/centre-mathematical-modelling-infectious-diseases)
 at the London School of Hygiene and Tropical Medicine as part of the
-[Epiverse Initiative](https://data.org/initiatives/epiverse/).
+[Epiverse-TRACE](https://data.org/initiatives/epiverse/).
 
 ## Installation
 


### PR DESCRIPTION
This PR
1. Fixes #145, by correcting links;
2. Fixes #157, by correcting Readme;
3. Fixes #158, but instead adds a [repostatus badge](https://www.repostatus.org/) rather than a {lifecycle} badge;
4. WIP on other fixes and additions;