### PR TITLE
Fix NEWS formatting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,10 +17,6 @@ This is the second release of _finalsize_, and includes:
     - The Cpplint workflow now includes linting and checking using Cppcheck for header files
 6. Updated `NEWS.md` file to track changes to the package.
 
-# finalsize 0.1.0.9000
-
-* Added a `NEWS.md` file to track changes to the package.
-
 # finalsize 0.1
 
 Initial release of _finalsize_, an R package to calculate the final size of an epidemic in a population with demographic variation in social contacts and in susceptibility to infection.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finalsize 0.2
+# finalsize 0.2.0
 
 This is the second release of _finalsize_, and includes:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ This is the second release of _finalsize_, and includes:
 Initial release of _finalsize_, an R package to calculate the final size of an epidemic in a population with demographic variation in social contacts and in susceptibility to infection.
 
 This release includes:
+
 1. A choice of equation solver functions.
 2. 100% code coverage,
 3. A basic usage vignette, and two advanced vignettes,


### PR DESCRIPTION
- Fix / remove non-existing version number
- Fix list formatting on [CRAN page](https://cran.r-project.org/web/packages/finalsize/news/news.html) (they use stricter markdown settings, which require a space before lists) 