### PR TITLE
Remove pkgs used only in development

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,7 +72,6 @@ LinkingTo:
     RcppEigen
 Suggests: 
     colorspace,
-    covr,
     dplyr,
     knitr,
     bookdown,
@@ -84,7 +83,6 @@ Suggests:
     ggplot2,
     ggtext,
     rmarkdown,
-    usethis,
     forcats,
     purrr,
     tidyr


### PR DESCRIPTION
The same way we don't include pkgdown in `Suggests`, we shouldn't include covr or usethis, which are only used as part of a user-invisible development process. This also removes some of the reverse dependency checking burden for these packages.