### PR TITLE
Update README and Get started

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -26,9 +26,9 @@ knitr::opts_chunk$set(
 
 _{{ packagename }}_ is an R package to calculate the final size of a SIR epidemic in populations with heterogeneity in social contacts and infection susceptibility.
 
-_{{ packagename }}_ provides estimates for the total proportion of a population infected over the course of an epidemic, and can account for a demographic distribution (such as age groups) and demography-specific contact patterns, as well as for heterogeneous susceptibility to infection between groups (such as due to age-group specific immune responses) and within groups (such as due to immunisation programs).
+_{{ packagename }}_ provides estimates for the total proportion of a population infected over the course of an epidemic, and can account for a demographic distribution (such as age groups) and demography-specific contact patterns, as well as for heterogeneous susceptibility to infection between groups (such as due to age-group specific immune responses) and within groups (such as due to immunisation programs). An advantage of this approach is that it requires fewer parameters to be defined compared to a model that simulates the full transmission dynamics over time, such as models in the [_epidemics_ package](https://epiverse-trace.github.io/epidemics/articles/epidemics.html).
 
-_{{ packagename }}_ implements methods outlined in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016.
+_{{ packagename }}_ implements methods outlined in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016. 
 
 _{{ packagename }}_ can help provide rough estimates of the effectiveness of pharmaceutical interventions in the form of immunisation programmes, or the effect of naturally acquired immunity through previous infection (see the vignette).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,7 @@ _{{ packagename }}_ is an R package to calculate the final size of a SIR epidemi
 
 _{{ packagename }}_ provides estimates for the total proportion of a population infected over the course of an epidemic, and can account for a demographic distribution (such as age groups) and demography-specific contact patterns, as well as for heterogeneous susceptibility to infection between groups (such as due to age-group specific immune responses) and within groups (such as due to immunisation programs). An advantage of this approach is that it requires fewer parameters to be defined compared to a model that simulates the full transmission dynamics over time, such as models in the [_epidemics_ package](https://epiverse-trace.github.io/epidemics/articles/epidemics.html).
 
-_{{ packagename }}_ implements methods outlined in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016. 
+_{{ packagename }}_ implements methods outlined in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016.
 
 _{{ packagename }}_ can help provide rough estimates of the effectiveness of pharmaceutical interventions in the form of immunisation programmes, or the effect of naturally acquired immunity through previous infection (see the vignette).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ infected over the course of an epidemic, and can account for a
 demographic distribution (such as age groups) and demography-specific
 contact patterns, as well as for heterogeneous susceptibility to
 infection between groups (such as due to age-group specific immune
-responses) and within groups (such as due to immunisation programs).
+responses) and within groups (such as due to immunisation programs). An
+advantage of this approach is that it requires fewer parameters to be
+defined compared to a model that simulates the full transmission
+dynamics over time, such as models in the [*epidemics*
+package](https://epiverse-trace.github.io/epidemics/articles/epidemics.html).
 
 *finalsize* implements methods outlined in Andreasen
 ([2011](#ref-andreasen2011)), Miller ([2012](#ref-miller2012)),
@@ -165,7 +169,7 @@ By contributing to this project, you agree to abide by its terms.
 citation("finalsize")
 #> To cite package 'finalsize' in publications use:
 #> 
-#>   Gupte P, Van Leeuwen E, Kucharski A (2023). _finalsize: Calculate the
+#>   Gupte P, Van Leeuwen E, Kucharski A (2024). _finalsize: Calculate the
 #>   Final Size of an Epidemic_. R package version 0.2.0.9000,
 #>   https://epiverse-trace.github.io/finalsize/,
 #>   <https://github.com/epiverse-trace/finalsize>.
@@ -175,7 +179,7 @@ citation("finalsize")
 #>   @Manual{,
 #>     title = {finalsize: Calculate the Final Size of an Epidemic},
 #>     author = {Pratik Gupte and Edwin {Van Leeuwen} and Adam Kucharski},
-#>     year = {2023},
+#>     year = {2024},
 #>     note = {R package version 0.2.0.9000, 
 #> https://epiverse-trace.github.io/finalsize/},
 #>     url = {https://github.com/epiverse-trace/finalsize},

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -17,6 +17,8 @@ vignette: >
 When analysing an epidemic-prone infection, such as pandemic influenza, it is important to understand how many infections there could be in total. The overall number of infections that occur during such an epidemic, is called the 'final epidemic size'.
 The expected final size of an epidemic can be calculated using methods detailed in @andreasen2011, @miller2012, @kucharski2014, and @bidari2016, and which are implemented in the _finalsize_ package.
 
+An advantage of the final size approach is that it is only necessary to define pathogen transmissibility and population susceptibility to calculate the epidemic size, rather than requiring estimates of additional time-dependent processes like the duration of infectiousness or delay from infection to onset of symptoms. So _finalsize_ will be particularly relevant for questions where understanding the overall size of an epidemic is more important than estimating its shape.
+
 ::: {.alert .alert-primary}
 ## Use case {-}
 


### PR DESCRIPTION
Talking to people interested in epidemic risk has reiterated that one of the big advantages of finalsize is the relatively few parameters that need defining (e.g. to estimate final size in _epidemics_ requires the user to define many more parameters, and hence do literature searches etc.) Have made some tweaks to description so this advantage/differentiation is stated more clearly in the foreground.


**Please check if the PR fulfills these requirements**

- [ X ] I have read the CONTRIBUTING guidelines 
- [ -] A new item has been added to `NEWS.md` – Not included as this PR is only small copy changes in documentation rather than any functionality/code changes.
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)
