### PR TITLE
Add defaults to final_size()

### DIFF
--- a/R/final_size.R
+++ b/R/final_size.R
@@ -1,19 +1,31 @@
 #' @title Final size of an epidemic
 #'
 #' @description `final_size` calculates the final size of an epidemic outbreak
-#' in a population with heterogeneous mixing, and with heterogeneous
-#' susceptibility to infection such as that conferred by an immunisation
-#' programme.
+#' with a given \eqn{R_0}, with options for specifying a population with
+#' heterogeneous mixing, and with heterogeneous susceptibility to infection
+#' such as that conferred by an immunisation programme.
 #'
 #' @details
-#' # Solver options
+#' ## Specifying heterogeneous mixing and susceptibility
+#' `final_size()` allows for heterogeneous population mixing and susceptibility,
+#' and this is described in the dedicated vignettes:
+#'
+#' 1. Heterogeneous population mixing: See vignette on
+#' "Modelling heterogeneous social contacts"
+#' (\code{vignette("varying_contacts", package = "finalsize")});
+#'
+#' 2. Heterogeneous susceptibility to infection: See vignette on
+#' "Modelling heterogeneous susceptibility"
+#' (\code{vignette("varying_susceptibility", package = "finalsize")}).
+#'
+#' ## Solver options
 #'
 #' The `control` argument accepts a list of solver options, with the iterative
 #' solver taking two extra arguments than the Newton solver. This is an optional
 #' argument, and default options are used within the solver functions if an
 #' argument is missing. Arguments provided override the solver defaults.
 #'
-#' ## Common options
+#' ### Common options
 #'
 #' 1. `iterations`: The number of iterations over which to solve for the final
 #' size, unless the error is below the solver tolerance. Default = 10000.
@@ -30,15 +42,24 @@
 #' @param r0 The basic reproductive number \eqn{R_0} of the disease.
 #' @param contact_matrix Social contact matrix. Entry \eqn{m_{ij}} gives average
 #' number of contacts in group \eqn{i} reported by participants in group \eqn{j}
+#' . Defaults to the singleton matrix \eqn{[1]}, representing a homogeneously
+#' mixing population.
 #' @param demography_vector Demography vector. Entry \eqn{v_{i}} gives
 #' proportion of total population in group \eqn{i} (model will normalise
 #' if needed).
+#' Defaults to `1`, representing a population where demographic structure is not
+#' important (or not known), and where all individuals are assumed to belong to
+#' the same demographic group.
 #' @param susceptibility A matrix giving the susceptibility of individuals in
 #' demographic group \eqn{i} and risk group \eqn{k}.
+#' Defaults to the singleton matrix \eqn{[1]}, representing a population where
+#' all individuals are fully susceptible to infection.
 #' @param p_susceptibility A matrix giving the probability that an individual
 #' in demography group \eqn{i} is in risk (or susceptibility) group \eqn{k}.
 #' Each row represents the overall distribution of individuals in demographic
 #' group \eqn{i} across risk groups, and each row *must sum to 1.0*.
+#' Defaults to the singleton matrix \eqn{[1]}, representing a population where
+#' all individuals are fully susceptible.
 #' @param solver Which solver to use. Options are "iterative" (default) or
 #' "newton", for the iterative solver, or the Newton solver, respectively.
 #' Special conditions apply when using the Newton solver, see the `control`
@@ -54,9 +75,13 @@
 #' \eqn{i}.
 #' @export
 #' @examples
+#' ## For a given R_0
+#' r0 <- 2.0
+#' final_size(r0)
+#'
+#' ## For a population with multiple demographic groups
 #' # load example POLYMOD data included in the package
 #' data(polymod_uk)
-#' r0 <- 2.0
 #' contact_matrix <- polymod_uk$contact_matrix
 #' demography_vector <- polymod_uk$demography_vector
 #'
@@ -65,7 +90,8 @@
 #' n_risk_grps <- 3
 #'
 #' # In this example, all risk groups from all age groups are fully
-#' # susceptible
+#' # susceptible, and the final size in each group is influenced only by
+#' # differences in social contacts
 #' susceptibility <- matrix(
 #'   data = 1, nrow = n_demo_grps, ncol = n_risk_grps
 #' )
@@ -85,7 +111,7 @@
 #'   p_susceptibility = p_susceptibility
 #' )
 #'
-#' # using manually specified solver settings for the iterative solver
+#' ## Using manually specified solver settings for the iterative solver
 #' control <- list(
 #'   iterations = 100,
 #'   tolerance = 1e-3,
@@ -103,7 +129,7 @@
 #'   control = control
 #' )
 #'
-#' # manual settings for the newton solver
+#' ## Using manually specified solver settings for the newton solver
 #' control <- list(
 #'   iterations = 100,
 #'   tolerance = 1e-3
@@ -119,10 +145,10 @@
 #'   control = control
 #' )
 final_size <- function(r0,
-                       contact_matrix,
-                       demography_vector,
-                       susceptibility,
-                       p_susceptibility,
+                       contact_matrix = matrix(1),
+                       demography_vector = 1,
+                       susceptibility = matrix(1),
+                       p_susceptibility = matrix(1),
                        solver = c("iterative", "newton"),
                        control = list()) {
   # check arguments input

--- a/README.Rmd
+++ b/README.Rmd
@@ -54,17 +54,22 @@ pak::pak("{{ gh_repo }}")
 
 ## Quick start
 
-The main function in _{{ packagename }}_ is `final_size()`, which calculates the final size of an epidemic.
-Helper functions included in _{{ packagename }}_ are provided to calculate the effective $R_0$, called $R_{eff}$, from demographic and susceptibility distribution data, while other helpers can convert between $R_0$ and the transmission rate $\lambda$.
-
-Here, an example using social contact data from the _socialmixr_ package investigates the final size of an epidemic when the disease has an R<sub>0</sub> of 1.5, and given three age groups of interest --- 0-19, 20-39 and 40+.
-The under-20 age group is assumed to be fully susceptible to the disease, whereas individuals aged over 20 are only half as susceptible as those under 20.
+The main function in _{{ packagename }}_ is `final_size()`, which calculates the final size of an epidemic given the $R_0$.
 
 ```{r}
 # load finalsize
 library(finalsize)
 
-# Load example POLYMOD data included with the package
+final_size(1.5)
+```
+
+Optionally, `final_size()` can estimate the epidemic size for populations with differences among demographic groups in their social contact patterns, in their susceptibility to infection.
+
+We can use social contact data (here, from the _socialmixr_ package) to estimate the final size of an epidemic when the disease has an R<sub>0</sub> of 1.5, and given three age groups of interest --- 0-19, 20-39 and 40+.
+The under-20 age group is assumed to be fully susceptible to the disease, whereas individuals aged over 20 are only half as susceptible as those under 20.
+
+```{r}
+# Load example POLYMOD social contacts data included with the package
 data(polymod_uk)
 
 # Define contact matrix (entry {ij} is contacts in group i reported by group j)
@@ -90,17 +95,21 @@ p_susceptibility <- matrix(
 # R0 of the disease
 r0 <- 1.5 # assumed for pandemic influenza
 
-# calculate the effective R0 using `r_eff()`
-r_eff(
+# Calculate the proportion of individuals infected in each age group
+final_size(
   r0 = r0,
   contact_matrix = contact_matrix,
   demography_vector = demography_vector,
   susceptibility = susceptibility,
   p_susceptibility = p_susceptibility
 )
+```
 
-# Calculate the proportion of individuals infected in each age group
-final_size(
+Helper functions included in _{{ packagename }}_ are provided to calculate the effective $R_0$, called $R_{eff}$, from demographic and susceptibility distribution data, while other helpers can convert between $R_0$ and the transmission rate $\lambda$.
+
+```{r}
+# calculate the effective R0 using `r_eff()`
+r_eff(
   r0 = r0,
   contact_matrix = contact_matrix,
   demography_vector = demography_vector,

--- a/README.md
+++ b/README.md
@@ -72,23 +72,30 @@ pak::pak("epiverse-trace/finalsize")
 ## Quick start
 
 The main function in *finalsize* is `final_size()`, which calculates the
-final size of an epidemic. Helper functions included in *finalsize* are
-provided to calculate the effective $R_0$, called $R_{eff}$, from
-demographic and susceptibility distribution data, while other helpers
-can convert between $R_0$ and the transmission rate $\lambda$.
+final size of an epidemic given the $R_0$.
 
-Here, an example using social contact data from the *socialmixr* package
-investigates the final size of an epidemic when the disease has an
+``` r
+# load finalsize
+library(finalsize)
+
+final_size(1.5)
+#>     demo_grp   susc_grp susceptibility p_infected
+#> 1 demo_grp_1 susc_grp_1              1  0.5828132
+```
+
+Optionally, `final_size()` can estimate the epidemic size for
+populations with differences among demographic groups in their social
+contact patterns, in their susceptibility to infection.
+
+We can use social contact data (here, from the *socialmixr* package) to
+estimate the final size of an epidemic when the disease has an
 R<sub>0</sub> of 1.5, and given three age groups of interest — 0-19,
 20-39 and 40+. The under-20 age group is assumed to be fully susceptible
 to the disease, whereas individuals aged over 20 are only half as
 susceptible as those under 20.
 
 ``` r
-# load finalsize
-library(finalsize)
-
-# Load example POLYMOD data included with the package
+# Load example POLYMOD social contacts data included with the package
 data(polymod_uk)
 
 # Define contact matrix (entry {ij} is contacts in group i reported by group j)
@@ -114,16 +121,6 @@ p_susceptibility <- matrix(
 # R0 of the disease
 r0 <- 1.5 # assumed for pandemic influenza
 
-# calculate the effective R0 using `r_eff()`
-r_eff(
-  r0 = r0,
-  contact_matrix = contact_matrix,
-  demography_vector = demography_vector,
-  susceptibility = susceptibility,
-  p_susceptibility = p_susceptibility
-)
-#> [1] 1.171758
-
 # Calculate the proportion of individuals infected in each age group
 final_size(
   r0 = r0,
@@ -136,6 +133,23 @@ final_size(
 #> 1   [0,20) susc_grp_1            1.0 0.32849966
 #> 2  [20,40) susc_grp_1            0.5 0.10532481
 #> 3      40+ susc_grp_1            0.5 0.06995193
+```
+
+Helper functions included in *finalsize* are provided to calculate the
+effective $R_0$, called $R_{eff}$, from demographic and susceptibility
+distribution data, while other helpers can convert between $R_0$ and the
+transmission rate $\lambda$.
+
+``` r
+# calculate the effective R0 using `r_eff()`
+r_eff(
+  r0 = r0,
+  contact_matrix = contact_matrix,
+  demography_vector = demography_vector,
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility
+)
+#> [1] 1.171758
 ```
 
 ## Package vignettes

--- a/man/final_size.Rd
+++ b/man/final_size.Rd
@@ -6,10 +6,10 @@
 \usage{
 final_size(
   r0,
-  contact_matrix,
-  demography_vector,
-  susceptibility,
-  p_susceptibility,
+  contact_matrix = matrix(1),
+  demography_vector = 1,
+  susceptibility = matrix(1),
+  p_susceptibility = matrix(1),
   solver = c("iterative", "newton"),
   control = list()
 )
@@ -18,19 +18,28 @@ final_size(
 \item{r0}{The basic reproductive number \eqn{R_0} of the disease.}
 
 \item{contact_matrix}{Social contact matrix. Entry \eqn{m_{ij}} gives average
-number of contacts in group \eqn{i} reported by participants in group \eqn{j}}
+number of contacts in group \eqn{i} reported by participants in group \eqn{j}
+. Defaults to the singleton matrix \eqn{[1]}, representing a homogeneously
+mixing population.}
 
 \item{demography_vector}{Demography vector. Entry \eqn{v_{i}} gives
 proportion of total population in group \eqn{i} (model will normalise
-if needed).}
+if needed).
+Defaults to \code{1}, representing a population where demographic structure is not
+important (or not known), and where all individuals are assumed to belong to
+the same demographic group.}
 
 \item{susceptibility}{A matrix giving the susceptibility of individuals in
-demographic group \eqn{i} and risk group \eqn{k}.}
+demographic group \eqn{i} and risk group \eqn{k}.
+Defaults to the singleton matrix \eqn{[1]}, representing a population where
+all individuals are fully susceptible to infection.}
 
 \item{p_susceptibility}{A matrix giving the probability that an individual
 in demography group \eqn{i} is in risk (or susceptibility) group \eqn{k}.
 Each row represents the overall distribution of individuals in demographic
-group \eqn{i} across risk groups, and each row \emph{must sum to 1.0}.}
+group \eqn{i} across risk groups, and each row \emph{must sum to 1.0}.
+Defaults to the singleton matrix \eqn{[1]}, representing a population where
+all individuals are fully susceptible.}
 
 \item{solver}{Which solver to use. Options are "iterative" (default) or
 "newton", for the iterative solver, or the Newton solver, respectively.
@@ -49,11 +58,27 @@ names are added of the form \verb{demo_grp_<i>}, for each demographic group
 }
 \description{
 \code{final_size} calculates the final size of an epidemic outbreak
-in a population with heterogeneous mixing, and with heterogeneous
-susceptibility to infection such as that conferred by an immunisation
-programme.
+with a given \eqn{R_0}, with options for specifying a population with
+heterogeneous mixing, and with heterogeneous susceptibility to infection
+such as that conferred by an immunisation programme.
 }
-\section{Solver options}{
+\details{
+\subsection{Specifying heterogeneous mixing and susceptibility}{
+
+\code{final_size()} allows for heterogeneous population mixing and susceptibility,
+and this is described in the dedicated vignettes:
+\enumerate{
+\item Heterogeneous population mixing: See vignette on
+"Modelling heterogeneous social contacts"
+(\code{vignette("varying_contacts", package = "finalsize")});
+\item Heterogeneous susceptibility to infection: See vignette on
+"Modelling heterogeneous susceptibility"
+(\code{vignette("varying_susceptibility", package = "finalsize")}).
+}
+}
+
+\subsection{Solver options}{
+
 The \code{control} argument accepts a list of solver options, with the iterative
 solver taking two extra arguments than the Newton solver. This is an optional
 argument, and default options are used within the solver functions if an
@@ -68,6 +93,8 @@ values are likely to lead to inaccurate final size estimates.
 }
 }
 
+}
+
 \subsection{Iterative solver options}{
 \enumerate{
 \item \code{step_rate}: The solver step rate. Defaults to 1.9 as a value found to
@@ -77,11 +104,14 @@ based on the solver error. Defaults to TRUE.
 }
 }
 }
-
 \examples{
+## For a given R_0
+r0 <- 2.0
+final_size(r0)
+
+## For a population with multiple demographic groups
 # load example POLYMOD data included in the package
 data(polymod_uk)
-r0 <- 2.0
 contact_matrix <- polymod_uk$contact_matrix
 demography_vector <- polymod_uk$demography_vector
 
@@ -90,7 +120,8 @@ n_demo_grps <- length(demography_vector)
 n_risk_grps <- 3
 
 # In this example, all risk groups from all age groups are fully
-# susceptible
+# susceptible, and the final size in each group is influenced only by
+# differences in social contacts
 susceptibility <- matrix(
   data = 1, nrow = n_demo_grps, ncol = n_risk_grps
 )
@@ -110,7 +141,7 @@ final_size(
   p_susceptibility = p_susceptibility
 )
 
-# using manually specified solver settings for the iterative solver
+## Using manually specified solver settings for the iterative solver
 control <- list(
   iterations = 100,
   tolerance = 1e-3,
@@ -128,7 +159,7 @@ final_size(
   control = control
 )
 
-# manual settings for the newton solver
+## Using manually specified solver settings for the newton solver
 control <- list(
   iterations = 100,
   tolerance = 1e-3

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -1,5 +1,30 @@
 #### Tests for basic finalsize functionality ####
 
+#### Test that a homogeneous population is handled by defaults ####
+
+test_that("final_size with default arguments", {
+  r0 <- 1.7
+  popsize <- 67e7
+  finalsize_shortcut <- final_size(r0)
+  finalsize_detailed <- final_size(
+    r0 = r0,
+    contact_matrix = matrix(1) / popsize,
+    demography_vector = popsize,
+    susceptibility = matrix(1),
+    p_susceptibility = matrix(1)
+  )
+
+  expect_identical(
+    finalsize_shortcut,
+    finalsize_detailed
+  )
+
+  expect_gt(
+    final_size(1.5)[, "p_infected"],
+    final_size(1.49)[, "p_infected"]
+  )
+})
+
 #### Prepare data ####
 r0 <- 2.0
 polymod <- socialmixr::polymod

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -131,4 +131,16 @@ This is the final epidemic size without accounting for heterogeneity in social c
 
 This value, of about `r scales::percent(round(final_size_data$p_infected, 2))` of the population infected, is easily converted to a count, and suggests that about `r scales::comma(final_size_data$p_infected * uk_pop, scale = 1e-6, suffix = " million")` people would be infected over the course of this epidemic.
 
+## A short-cut for homogeneous populations
+
+The example above explains the steps that go into final size calculation.
+For one very specific use-case, wherein the population is assumed to have homogeneous mixing (i.e., groups do not differ in their social contacts), and homogeneous and full susceptibility to infection, the final size calculation only depends on the $R_0$ of the epidemic.
+
+In this case, the final size calculation can be simplified to `final_size(r0)`, with all other parameters taking their default values, which assume homogeneous social contacts and susceptibility.
+
+```{r}
+final_size(r0)
+```
+
+
 ## References


### PR DESCRIPTION
This PR fixes #180 by providing default values for all population parameters in `final_size()`.

This allows final size calculation given only the epidemic $R_0$, assuming a homogeneously mixing population with full susceptibility, e.g.:

```r
final_size(1.3)
```