### PR TITLE
Fix ORCID links

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,6 +44,18 @@ keywords:
 - sdg-3
 references:
 - type: software
+  title: 'R: A Language and Environment for Statistical Computing'
+  notes: Depends
+  url: https://www.R-project.org/
+  authors:
+  - name: R Core Team
+  location:
+    name: Vienna, Austria
+  year: '2024'
+  institution:
+    name: R Foundation for Statistical Computing
+  version: '>= 2.10'
+- type: software
   title: checkmate
   abstract: 'checkmate: Fast and Versatile Argument Checks'
   notes: Imports
@@ -54,7 +66,7 @@ references:
     given-names: Michel
     email: michellang@gmail.com
     orcid: https://orcid.org/0000-0001-9754-0393
-  year: '2023'
+  year: '2024'
 - type: software
   title: Rcpp
   abstract: 'Rcpp: Seamless R and C++ Integration'
@@ -80,24 +92,19 @@ references:
     given-names: Douglas
   - family-names: Chambers
     given-names: John
-  year: '2023'
+  year: '2024'
 - type: software
-  title: RcppEigen
-  abstract: 'RcppEigen: ''Rcpp'' Integration for the ''Eigen'' Templated Linear Algebra
-    Library'
-  notes: LinkingTo
-  url: https://dirk.eddelbuettel.com/code/rcpp.eigen.html
-  repository: https://CRAN.R-project.org/package=RcppEigen
+  title: bookdown
+  abstract: 'bookdown: Authoring Books and Technical Documents with R Markdown'
+  notes: Suggests
+  url: https://pkgs.rstudio.com/bookdown/
+  repository: https://CRAN.R-project.org/package=bookdown
   authors:
-  - family-names: Bates
-    given-names: Douglas
-  - family-names: Eddelbuettel
-    given-names: Dirk
-  - family-names: Francois
-    given-names: Romain
-  - family-names: Eigen
-    given-names: Yixuan Qiu; the authors of Eigen for the included version of
-  year: '2023'
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  year: '2024'
 - type: software
   title: colorspace
   abstract: 'colorspace: A Toolbox for Manipulating and Assessing Colors and Palettes'
@@ -136,7 +143,7 @@ references:
     given-names: Achim
     email: Achim.Zeileis@R-project.org
     orcid: https://orcid.org/0000-0003-0918-3766
-  year: '2023'
+  year: '2024'
 - type: software
   title: dplyr
   abstract: 'dplyr: A Grammar of Data Manipulation'
@@ -160,105 +167,18 @@ references:
     given-names: Davis
     email: davis@posit.co
     orcid: https://orcid.org/0000-0003-4777-038X
-  year: '2023'
+  year: '2024'
 - type: software
-  title: knitr
-  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
+  title: forcats
+  abstract: 'forcats: Tools for Working with Categorical Variables (Factors)'
   notes: Suggests
-  url: https://yihui.org/knitr/
-  repository: https://CRAN.R-project.org/package=knitr
+  url: https://forcats.tidyverse.org/
+  repository: https://CRAN.R-project.org/package=forcats
   authors:
-  - family-names: Xie
-    given-names: Yihui
-    email: xie@yihui.name
-    orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2023'
-- type: software
-  title: bookdown
-  abstract: 'bookdown: Authoring Books and Technical Documents with R Markdown'
-  notes: Suggests
-  url: https://pkgs.rstudio.com/bookdown/
-  repository: https://CRAN.R-project.org/package=bookdown
-  authors:
-  - family-names: Xie
-    given-names: Yihui
-    email: xie@yihui.name
-    orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2023'
-- type: software
-  title: scales
-  abstract: 'scales: Scale Functions for Visualization'
-  notes: Suggests
-  url: https://scales.r-lib.org
-  repository: https://CRAN.R-project.org/package=scales
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  - family-names: Pedersen
-    given-names: Thomas Lin
-    email: thomas.pedersen@posit.co
-    orcid: https://orcid.org/0000-0002-5147-4711
-  - family-names: Seidel
-    given-names: Dana
-  year: '2023'
-- type: software
-  title: socialmixr
-  abstract: 'socialmixr: Social Mixing Matrices for Infectious Disease Modelling'
-  notes: Suggests
-  url: https://epiforecasts.io/socialmixr/
-  repository: https://CRAN.R-project.org/package=socialmixr
-  authors:
-  - family-names: Funk
-    given-names: Sebastian
-    email: sebastian.funk@lshtm.ac.uk
-  - family-names: Willem
-    given-names: Lander
-  - family-names: Gruson
-    given-names: Hugo
-  year: '2023'
-- type: software
-  title: testthat
-  abstract: 'testthat: Unit Testing for R'
-  notes: Suggests
-  url: https://testthat.r-lib.org
-  repository: https://CRAN.R-project.org/package=testthat
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  year: '2023'
-  version: '>= 3.0.0'
-- type: software
-  title: tibble
-  abstract: 'tibble: Simple Data Frames'
-  notes: Suggests
-  url: https://tibble.tidyverse.org/
-  repository: https://CRAN.R-project.org/package=tibble
-  authors:
-  - family-names: Müller
-    given-names: Kirill
-    email: kirill@cynkra.com
-    orcid: https://orcid.org/0000-0002-1416-3412
   - family-names: Wickham
     given-names: Hadley
     email: hadley@rstudio.com
-  year: '2023'
-- type: software
-  title: xml2
-  abstract: 'xml2: Parse XML'
-  notes: Suggests
-  url: https://xml2.r-lib.org/
-  repository: https://CRAN.R-project.org/package=xml2
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  - family-names: Hester
-    given-names: Jim
-  - family-names: Ooms
-    given-names: Jeroen
-  year: '2023'
+  year: '2024'
 - type: software
   title: ggplot2
   abstract: 'ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics'
@@ -293,7 +213,7 @@ references:
   - family-names: Dunnington
     given-names: Dewey
     orcid: https://orcid.org/0000-0002-9415-4582
-  year: '2023'
+  year: '2024'
 - type: software
   title: ggtext
   abstract: 'ggtext: Improved Text Rendering Support for ''ggplot2'''
@@ -309,7 +229,34 @@ references:
     given-names: Brenton M.
     email: brenton@wiernik.org
     orcid: https://orcid.org/0000-0001-9560-6336
-  year: '2023'
+  year: '2024'
+- type: software
+  title: knitr
+  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
+  notes: Suggests
+  url: https://yihui.org/knitr/
+  repository: https://CRAN.R-project.org/package=knitr
+  authors:
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  year: '2024'
+- type: software
+  title: purrr
+  abstract: 'purrr: Functional Programming Tools'
+  notes: Suggests
+  url: https://purrr.tidyverse.org/
+  repository: https://CRAN.R-project.org/package=purrr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@rstudio.com
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: Henry
+    given-names: Lionel
+    email: lionel@rstudio.com
+  year: '2024'
 - type: software
   title: rmarkdown
   abstract: 'rmarkdown: Dynamic Documents for R'
@@ -352,33 +299,81 @@ references:
     given-names: Richard
     email: rich@posit.co
     orcid: https://orcid.org/0000-0003-3925-190X
-  year: '2023'
+  year: '2024'
 - type: software
-  title: forcats
-  abstract: 'forcats: Tools for Working with Categorical Variables (Factors)'
+  title: scales
+  abstract: 'scales: Scale Functions for Visualization'
   notes: Suggests
-  url: https://forcats.tidyverse.org/
-  repository: https://CRAN.R-project.org/package=forcats
+  url: https://scales.r-lib.org
+  repository: https://CRAN.R-project.org/package=scales
   authors:
   - family-names: Wickham
     given-names: Hadley
-    email: hadley@rstudio.com
-  year: '2023'
+    email: hadley@posit.co
+  - family-names: Pedersen
+    given-names: Thomas Lin
+    email: thomas.pedersen@posit.co
+    orcid: https://orcid.org/0000-0002-5147-4711
+  - family-names: Seidel
+    given-names: Dana
+  year: '2024'
 - type: software
-  title: purrr
-  abstract: 'purrr: Functional Programming Tools'
+  title: socialmixr
+  abstract: 'socialmixr: Social Mixing Matrices for Infectious Disease Modelling'
   notes: Suggests
-  url: https://purrr.tidyverse.org/
-  repository: https://CRAN.R-project.org/package=purrr
+  url: https://epiforecasts.io/socialmixr/
+  repository: https://CRAN.R-project.org/package=socialmixr
+  authors:
+  - family-names: Funk
+    given-names: Sebastian
+    email: sebastian.funk@lshtm.ac.uk
+  - family-names: Willem
+    given-names: Lander
+  - family-names: Gruson
+    given-names: Hugo
+  year: '2024'
+- type: software
+  title: spelling
+  abstract: 'spelling: Tools for Spell Checking in R'
+  notes: Suggests
+  url: https://docs.ropensci.org/spelling/
+  repository: https://CRAN.R-project.org/package=spelling
+  authors:
+  - family-names: Ooms
+    given-names: Jeroen
+    email: jeroen@berkeley.edu
+    orcid: https://orcid.org/0000-0002-4035-0289
+  - family-names: Hester
+    given-names: Jim
+    email: james.hester@rstudio.com
+  year: '2024'
+- type: software
+  title: testthat
+  abstract: 'testthat: Unit Testing for R'
+  notes: Suggests
+  url: https://testthat.r-lib.org
+  repository: https://CRAN.R-project.org/package=testthat
   authors:
   - family-names: Wickham
     given-names: Hadley
+    email: hadley@posit.co
+  year: '2024'
+  version: '>= 3.0.0'
+- type: software
+  title: tibble
+  abstract: 'tibble: Simple Data Frames'
+  notes: Suggests
+  url: https://tibble.tidyverse.org/
+  repository: https://CRAN.R-project.org/package=tibble
+  authors:
+  - family-names: Müller
+    given-names: Kirill
+    email: kirill@cynkra.com
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Wickham
+    given-names: Hadley
     email: hadley@rstudio.com
-    orcid: https://orcid.org/0000-0003-4757-117X
-  - family-names: Henry
-    given-names: Lionel
-    email: lionel@rstudio.com
-  year: '2023'
+  year: '2024'
 - type: software
   title: tidyr
   abstract: 'tidyr: Tidy Messy Data'
@@ -394,16 +389,36 @@ references:
     email: davis@posit.co
   - family-names: Girlich
     given-names: Maximilian
-  year: '2023'
+  year: '2024'
 - type: software
-  title: 'R: A Language and Environment for Statistical Computing'
-  notes: Depends
-  url: https://www.R-project.org/
+  title: xml2
+  abstract: 'xml2: Parse XML'
+  notes: Suggests
+  url: https://xml2.r-lib.org/
+  repository: https://CRAN.R-project.org/package=xml2
   authors:
-  - name: R Core Team
-  location:
-    name: Vienna, Austria
-  year: '2023'
-  institution:
-    name: R Foundation for Statistical Computing
-  version: '>= 2.10'
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  - family-names: Hester
+    given-names: Jim
+  - family-names: Ooms
+    given-names: Jeroen
+  year: '2024'
+- type: software
+  title: RcppEigen
+  abstract: 'RcppEigen: ''Rcpp'' Integration for the ''Eigen'' Templated Linear Algebra
+    Library'
+  notes: LinkingTo
+  url: https://dirk.eddelbuettel.com/code/rcpp.eigen.html
+  repository: https://CRAN.R-project.org/package=RcppEigen
+  authors:
+  - family-names: Bates
+    given-names: Douglas
+  - family-names: Eddelbuettel
+    given-names: Dirk
+  - family-names: Francois
+    given-names: Romain
+  - family-names: Eigen
+    given-names: Yixuan Qiu; the authors of Eigen for the included version of
+  year: '2024'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,21 +3,21 @@ Title: Calculate the Final Size of an Epidemic
 Version: 0.2.0.9000
 Authors@R: c(
     person("Pratik", "Gupte", , "pratik.gupte@lshtm.ac.uk", role = c("aut", "cre", "cph"),
-           comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819")),
+           comment = c(ORCID = "0000-0001-5294-7819")),
     person("Edwin", "Van Leeuwen", , "edwin.vanleeuwen@ukhsa.gov.uk", role = c("aut", "cph"),
-           comment = c(ORCID = "https://orcid.org/0000-0002-2383-5305")),
+           comment = c(ORCID = "0000-0002-2383-5305")),
     person("Adam", "Kucharski", , "adam.kucharski@lshtm.ac.uk", role = c("aut", "cph"),
-           comment = c(ORCID = "https://orcid.org/0000-0001-8814-9421")),
+           comment = c(ORCID = "0000-0001-8814-9421")),
     person("Rosalind", "Eggo", , "r.eggo@lshtm.ac.uk", role = "ctb",
-           comment = c(ORCID = "https://orcid.org/0000-0002-0362-6717")),
+           comment = c(ORCID = "0000-0002-0362-6717")),
     person("Hugo", "Gruson", , "hugo.gruson@data.org", role = "ctb",
-           comment = c(ORCID = "https://orcid.org/0000-0002-4094-1476")),
+           comment = c(ORCID = "0000-0002-4094-1476")),
     person("Thibaut", "Jombart", , "thibaut@data.org", role = "ctb",
-           comment = c(ORCID = "https://orcid.org/0000-0003-3796-2097")),
+           comment = c(ORCID = "0000-0003-3796-2097")),
     person("Andree", "Valle-Campos", , "andree.valle-campos@lshtm.ac.uk", role = "ctb",
-           comment = c(ORCID = "https://orcid.org/0000-0002-7779-481X")),
+           comment = c(ORCID = "0000-0002-7779-481X")),
     person("Joshua W.", "Lambert", , "joshua.lambert@lshtm.ac.uk", role = "rev",
-           comment = c(ORCID = "https://orcid.org/0000-0001-5218-3046"))
+           comment = c(ORCID = "0000-0001-5218-3046"))
   )
 Description: Calculate the final size of a
     susceptible-infectious-recovered epidemic in a population with


### PR DESCRIPTION
This PR fixes the ORCID links for the `pkgdown` page. See also upstream change to the template - https://github.com/epiverse-trace/packagetemplate/pull/126