### PR TITLE
Release patch v0.2.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: 'To cite package "finalsize" in publications use:'
 type: software
 license: MIT
 title: 'finalsize: Calculate the Final Size of an Epidemic'
-version: 0.2.0.9000
+version: 0.2.1
 abstract: Calculate the final size of a susceptible-infectious-recovered epidemic
   in a population with demographic variation in contact patterns and susceptibility
   to disease, as discussed in Miller (2012) <https://doi.org/10.1007/s11538-012-9749-6>.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finalsize
 Title: Calculate the Final Size of an Epidemic
-Version: 0.2.0.9000
+Version: 0.2.1
 Authors@R: c(
     person("Pratik", "Gupte", , "pratik.gupte@lshtm.ac.uk", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ This patch adds:
 
 2. Combines the documentation for the functions `r_eff()`, `r0_to_lambda()`, and `lambda_to_r0()` under the name 'r0_conversions';
 
-3. Adds vignettes on the theoretical background and on projecting re-emergence of a disease due to demographic turnover;
+3. Adds vignettes on the theoretical background and on projecting re-emergence of a disease due to demographic turnover (#193, #194 by @adamkucharski);
 
 4. Streamlines the examples in the Readme;
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,29 @@
+# finalsize 0.2.1
+
+This patch adds:
+
+1. Default values for the contact matrix, susceptibility matrix, and susceptibility distribution matrix to allow quick estimates of final size for a given $R_0$ in a population with homogeneous mixing and full susceptibility (#180);
+
+2. Combines the documentation for the functions `r_eff()`, `r0_to_lambda()`, and `lambda_to_r0()` under the name 'r0_conversions';
+
+3. Adds vignettes on the theoretical background and on projecting re-emergence of a disease due to demographic turnover;
+
+4. Streamlines the examples in the Readme;
+
+5. Replaces the PNG logo in the Readme with an SVG version;
+
+6. Updates the GitHub Actions workflow YAMLs, the `.lintr` config file, `_pkgdown.yml`, `.Rbuildignore`, `CITATION.cff` and `CRAN-SUBMISSION`; workflows and configuration files bring the package in line with {packagetemplate} (#181, #186, #188).
+
+7. Standardises the `DESCRIPTION` file.
+
+8. Adds package-level documentation.
+
+9. Adds spellchecking and the `WORDLIST` file.
+
+10. Adds tools to check that the package does not modify the global state, code to flag any partial matching of function arguments,.
+
+11. Updates references cited in the vignettes.
+
 # finalsize 0.2.0
 
 This is the second release of _finalsize_, and includes:

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -27,9 +27,11 @@ Subekshya
 Viggo
 Wei
 Xinying
+YAMLs
 cdots
 codecov
 com
+config
 dF
 dI
 dS
@@ -51,6 +53,7 @@ mathrm
 md
 overbrace
 packagename
+packagetemplate
 rightarrow
 socialmixr
 suscept

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,1 +1,24 @@
+# Platform
+
+|field    |value                                      |
+|:--------|:------------------------------------------|
+|version  |R version 4.3.1 (2023-06-16)               |
+|os       |macOS Sonoma 14.4.1                        |
+|system   |aarch64, darwin20                          |
+|ui       |RStudio                                    |
+|language |(EN)                                       |
+|collate  |en_US.UTF-8                                |
+|ctype    |en_US.UTF-8                                |
+|tz       |Europe/London                              |
+|date     |2024-04-09                                 |
+|rstudio  |2023.06.2+561 Mountain Hydrangea (desktop) |
+|pandoc   |2.19 @ /usr/local/bin/pandoc               |
+
+# Dependencies
+
+|package   |old   |new   |Δ  |
+|:---------|:-----|:-----|:--|
+|finalsize |0.2.0 |0.2.1 |*  |
+
 # Revdeps
+

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,0 +1,7 @@
+## revdepcheck results
+
+We checked 0 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 0 new problems
+ * We failed to check 0 packages
+

--- a/vignettes/demographic_turnover.Rmd
+++ b/vignettes/demographic_turnover.Rmd
@@ -195,3 +195,5 @@ ggplot(r_eff_df) +
     y = "Effective R (mean and 95% CI)"
   )
 ```
+
+## References

--- a/vignettes/theoretical_background.Rmd
+++ b/vignettes/theoretical_background.Rmd
@@ -7,6 +7,7 @@ output:
     code_folding: show
 pkgdown:
   as_is: true
+bibliography: references.json
 link-citations: true
 vignette: >
   %\VignetteEncoding{UTF-8}
@@ -57,7 +58,7 @@ This equation doesn't have an analytical solution, but there are various methods
 
 ## Varying susceptibility
 
-We can extend the above formulation to account for variable susceptibility among individuals, following the methods outlined in [Miller (2012)](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3506030/). First, we define $p(x)$ to be the probability density for a randomly chosen individual to be of susceptibility type $x$. If we define the probability an individual of type $x$ to be ultimately infected as $\phi(x)$, then the overall proportion of the population to be infected is defined as follows, depending on whether $p(x)$ is a continuous or discrete distribution:
+We can extend the above formulation to account for variable susceptibility among individuals, following the methods outlined in @miller2012. First, we define $p(x)$ to be the probability density for a randomly chosen individual to be of susceptibility type $x$. If we define the probability an individual of type $x$ to be ultimately infected as $\phi(x)$, then the overall proportion of the population to be infected is defined as follows, depending on whether $p(x)$ is a continuous or discrete distribution:
 
 $$
 \hat\phi = \int_0^\infty \phi(x) p(x) dx \\
@@ -83,7 +84,7 @@ $$
 
 ## Final size equation with heterogeneous mixing
 
-We can extend the same derivation for the above homogenous model for populations with multiple age groups, following [Andreasen et al](about:blank). The age-dependent ODEs are defined as follows:
+We can extend the same derivation for the above homogenous model for populations with multiple age groups, following @andreasen2011. The age-dependent ODEs are defined as follows:
 
 $$
 \frac{d S(a,t)}{d t} = -S(a,t) \sum_b \beta_{ab} I(b,t) \\
@@ -109,3 +110,4 @@ $$
 $$
 where $\mathbf{R}$ is a matrix with entries $R_{i,j}$. Once again, we can use Newton's method, this time with $\underline\phi$ as a vector, and hence we need to solve a set of linear equations in step 2.
 
+## References

--- a/vignettes/varying_susceptibility.Rmd
+++ b/vignettes/varying_susceptibility.Rmd
@@ -290,7 +290,7 @@ In general terms, this could be interpreted as the rate of vaccine uptake, or as
 
 ### Getting data on within-group susceptibility differences {-}
 
-For within-group differences in susceptibility, such as due to immunisation, users could obtain this information from [age-specific vaccination uptake statistics from national governments (here, the UK)](https://coronavirus.data.gov.uk/details/vaccinations?areaType=nation%26areaName=England#card-vaccination_uptake_by_vaccination_date_age_demographics).
+For within-group differences in susceptibility, such as due to immunisation, users could obtain this information from [age-specific vaccination uptake statistics from national governments (here, the UK)](https://ukhsa-dashboard.data.gov.uk).
 When antibody response decays are known for an immunisation course [@iyer2020], more detailed statistics on the [percentage of people vaccinated in the preceding few months only (here, in the UK)](https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19latestinsights/vaccines), may be more informative.
 :::
 


### PR DESCRIPTION
This PR increments the package version to v0.2.1. This is aimed at getting fixes to #180 in to the CRAN release (see #201), as well as updating the release version of the website with the theoretical background and demographic turnover vignettes.