### PR TITLE
Fix pkgdown YAML

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,7 @@
 url: https://epiverse-trace.github.io/finalsize/
 template:
   package: epiversetheme
+  bootstrap: 5
 development:
   mode: auto
 articles:


### PR DESCRIPTION
This PR adds a manual specification of Bootstrap version 5 for the pkgdown website due to a breaking change in pkgdown.