### PR TITLE
Return demography-susceptibility group sizes and N infected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ Maintainer is changing to @rozeggo (#212).
 
 5. Added continuous benchmarking workflows using {touchstone} following the pattern of {epiforecasts/EpiNow2} (#212).
 
+6. Updated `final_size()` to return the demography-susceptibility group sizes and the absolute value of individuals infected as columns.
+
 # finalsize 0.2.1
 
 This patch adds:

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -67,8 +67,10 @@
 #' @param control A list of named solver options, see *Solver options*.
 #'
 #' @keywords epidemic model
-#' @return A data.frame of the proportion of infected individuals, within each
-#' demography group and susceptibility group combination.
+#' @return A data.frame of the proportion and number of infected individuals,
+#' within each demography group and susceptibility group combination.
+#' The sizes of each demography-susceptibility combination are also returned in
+#' a column.
 #' If the demography groups and susceptibility groups are named, these
 #' names are added to relevant columns. If the groups are not named, synthetic
 #' names are added of the form `demo_grp_<i>`, for each demographic group

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -277,7 +277,9 @@ final_size <- function(r0,
       each = nrow(susceptibility)
     ),
     susceptibility = as.vector(susceptibility),
-    p_infected = epi_final_size
+    group_size = demography_vector_spread,
+    p_infected = epi_final_size,
+    n_infected = demography_vector_spread * epi_final_size
   )
   epi_final_size
 }

--- a/man/final_size.Rd
+++ b/man/final_size.Rd
@@ -49,8 +49,10 @@ argument.}
 \item{control}{A list of named solver options, see \emph{Solver options}.}
 }
 \value{
-A data.frame of the proportion of infected individuals, within each
-demography group and susceptibility group combination.
+A data.frame of the proportion and number of infected individuals,
+within each demography group and susceptibility group combination.
+The sizes of each demography-susceptibility combination are also returned in
+a column.
 If the demography groups and susceptibility groups are named, these
 names are added to relevant columns. If the groups are not named, synthetic
 names are added of the form \verb{demo_grp_<i>}, for each demographic group

--- a/tests/testthat/_snaps/statistical_correctness.md
+++ b/tests/testthat/_snaps/statistical_correctness.md
@@ -3,56 +3,56 @@
     Code
       epi_outcome_iterative
     Output
-        demo_grp       susc_grp susceptibility p_infected
-      1   [0,20)      immunised           0.10 0.02979109
-      2  [20,40)      immunised           0.10 0.02279411
-      3      40+      immunised           0.10 0.01603771
-      4   [0,20) part-immunised           0.55 0.15324273
-      5  [20,40) part-immunised           0.55 0.11910648
-      6      40+ part-immunised           0.55 0.08508340
-      7   [0,20)    susceptible           1.00 0.26098610
-      8  [20,40)    susceptible           1.00 0.20592640
-      9      40+    susceptible           1.00 0.14928409
+        demo_grp       susc_grp susceptibility group_size p_infected n_infected
+      1   [0,20)      immunised           0.10    4933097 0.02979109   146962.3
+      2  [20,40)      immunised           0.10    5508767 0.02279411   125567.4
+      3      40+      immunised           0.10    9653720 0.01603771   154823.5
+      4   [0,20) part-immunised           0.55    4933097 0.15324273   755961.2
+      5  [20,40) part-immunised           0.55    5508767 0.11910648   656129.9
+      6      40+ part-immunised           0.55    9653720 0.08508340   821371.3
+      7   [0,20)    susceptible           1.00    4933097 0.26098610  1287469.7
+      8  [20,40)    susceptible           1.00    5508767 0.20592640  1134400.6
+      9      40+    susceptible           1.00    9653720 0.14928409  1441146.7
 
 ---
 
     Code
       epi_outcome_newton
     Output
-        demo_grp       susc_grp susceptibility p_infected
-      1   [0,20)      immunised           0.10 0.02979101
-      2  [20,40)      immunised           0.10 0.02279407
-      3      40+      immunised           0.10 0.01603768
-      4   [0,20) part-immunised           0.55 0.15324236
-      5  [20,40) part-immunised           0.55 0.11910629
-      6      40+ part-immunised           0.55 0.08508329
-      7   [0,20)    susceptible           1.00 0.26098551
-      8  [20,40)    susceptible           1.00 0.20592609
-      9      40+    susceptible           1.00 0.14928389
+        demo_grp       susc_grp susceptibility group_size p_infected n_infected
+      1   [0,20)      immunised           0.10    4933097 0.02979101   146961.9
+      2  [20,40)      immunised           0.10    5508767 0.02279407   125567.2
+      3      40+      immunised           0.10    9653720 0.01603768   154823.3
+      4   [0,20) part-immunised           0.55    4933097 0.15324236   755959.4
+      5  [20,40) part-immunised           0.55    5508767 0.11910629   656128.8
+      6      40+ part-immunised           0.55    9653720 0.08508329   821370.2
+      7   [0,20)    susceptible           1.00    4933097 0.26098551  1287466.8
+      8  [20,40)    susceptible           1.00    5508767 0.20592609  1134398.9
+      9      40+    susceptible           1.00    9653720 0.14928389  1441144.8
 
 # Newton solver is correct in complex case
 
     Code
       epi_outcome
     Output
-          demo_grp   susc_grp susceptibility p_infected
-      1 demo_grp_1 susc_grp_1              1  0.4656377
-      2 demo_grp_2 susc_grp_1              1  0.4636757
-      3 demo_grp_3 susc_grp_1              1  0.3987979
-      4 demo_grp_4 susc_grp_1              1  0.3364829
-      5 demo_grp_5 susc_grp_1              1  0.2469828
-      6 demo_grp_6 susc_grp_1              1  0.1485668
+          demo_grp   susc_grp susceptibility group_size p_infected n_infected
+      1 demo_grp_1 susc_grp_1              1   10831795  0.4656377  5043691.8
+      2 demo_grp_2 susc_grp_1              1   11612456  0.4636757  5384413.8
+      3 demo_grp_3 susc_grp_1              1   13511496  0.3987979  5388355.9
+      4 demo_grp_4 susc_grp_1              1   11499398  0.3364829  3869350.8
+      5 demo_grp_5 susc_grp_1              1    8167102  0.2469828  2017133.5
+      6 demo_grp_6 susc_grp_1              1    4587765  0.1485668   681589.6
 
 # Iterative solver is correct in complex case
 
     Code
       epi_outcome
     Output
-          demo_grp   susc_grp susceptibility p_infected
-      1 demo_grp_1 susc_grp_1              1  0.4656377
-      2 demo_grp_2 susc_grp_1              1  0.4636758
-      3 demo_grp_3 susc_grp_1              1  0.3987979
-      4 demo_grp_4 susc_grp_1              1  0.3364829
-      5 demo_grp_5 susc_grp_1              1  0.2469827
-      6 demo_grp_6 susc_grp_1              1  0.1485668
+          demo_grp   susc_grp susceptibility group_size p_infected n_infected
+      1 demo_grp_1 susc_grp_1              1   10831795  0.4656377  5043692.4
+      2 demo_grp_2 susc_grp_1              1   11612456  0.4636758  5384414.6
+      3 demo_grp_3 susc_grp_1              1   13511496  0.3987979  5388355.7
+      4 demo_grp_4 susc_grp_1              1   11499398  0.3364829  3869350.4
+      5 demo_grp_5 susc_grp_1              1    8167102  0.2469827  2017133.2
+      6 demo_grp_6 susc_grp_1              1    4587765  0.1485668   681589.4
 

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -14,9 +14,10 @@ test_that("final_size with default arguments", {
     p_susceptibility = matrix(1)
   )
 
+  # test only proportion as numbers differ
   expect_identical(
-    finalsize_shortcut,
-    finalsize_detailed
+    finalsize_shortcut$p_infected,
+    finalsize_detailed$p_infected
   )
 
   expect_gt(
@@ -78,7 +79,10 @@ test_that("Finalsize returns correct demography names", {
   # expect that data.frame has correct names
   expect_identical(
     colnames(epi_outcome),
-    c("demo_grp", "susc_grp", "susceptibility", "p_infected")
+    c(
+      "demo_grp", "susc_grp", "susceptibility", "group_size",
+      "p_infected", "n_infected"
+    )
   )
 
   # check for names

--- a/vignettes/finalsize.Rmd
+++ b/vignettes/finalsize.Rmd
@@ -127,9 +127,9 @@ final_size_data <- final_size(
 final_size_data
 ```
 
-This is the final epidemic size without accounting for heterogeneity in social contacts by age or other factors, and without accounting for variation in susceptibility to infection between or within demographic groups.
+This is the final epidemic size -- in proportional as well as absolute terms -- without accounting for heterogeneity in social contacts by age or other factors, and without accounting for variation in susceptibility to infection between or within demographic groups.
 
-This value, of about `r scales::percent(round(final_size_data$p_infected, 2))` of the population infected, is easily converted to a count, and suggests that about `r scales::comma(final_size_data$p_infected * uk_pop, scale = 1e-6, suffix = " million")` people would be infected over the course of this epidemic.
+This value, of about `r scales::percent(round(final_size_data$p_infected, 2))` of the population or about `r scales::comma(final_size_data$n_infected, scale = 1e-6, suffix = " million")` people, is the expected proportion and number of individuals that would be infected over the course of this epidemic.
 
 ## A short-cut for homogeneous populations
 


### PR DESCRIPTION
Hi @adamkucharski, I had some time on my hands and this seemed like an easy request by @BlackEdder so I'm just popping this PR in. I've updated one vignette but there may be other instances where the new output could simplify code.

* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [x] A new item has been added to `NEWS.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR aims to fix #219 by:

1. Returning the demography-susceptibility group sizes as part of `final_size()` output; these are already [calculated in the function as `demography_vector_spread`](https://github.com/epiverse-trace/finalsize/blob/4addd753bf06bd59cf677ce443fab9d885418797/R/final_size.R#L217).
2. Additionally, provides the `n_infected` column for the product of group size and `p_infected`, as this is the end goal of Edwin's request;
3. Updates the function documentation for new output columns;
4. Updates tests, including adding tests for correctness, for new output columns.

Note that the continuous benchmarking workflow seems to be broken as an action workflow needs to be updated.

* **What is the current behavior?** (You can also link to an open issue here)

See issue #219.

* **What is the new behavior (if this is a feature change)?**

New columns in the output of `final_size()`: `group_size` and `n_infected`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Unlikely.