### PR TITLE
Add contact scaling functionality

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@ Maintainer is changing to @rozeggo (#212).
 
 6. Updated `final_size()` to return the demography-susceptibility group sizes and the absolute value of individuals infected as columns.
 
+7. Added the `contact_scaling` argument to `final_size()` and `r_eff()` that allows scaling contact matrices; added tests and a brief vignette to show this functionality.
+
 # finalsize 0.2.1
 
 This patch adds:

--- a/R/final_size.R
+++ b/R/final_size.R
@@ -198,6 +198,8 @@ final_size <- function(r0,
     "Error: contact_scaling must be a number or length of demography vector" =
       is.numeric(contact_scaling) && (length(contact_scaling) == 1 ||
         length(contact_scaling) == length(demography_vector)),
+    "Error: contact_scaling must be in the range 0.0 -- 1.0" =
+      all(contact_scaling >= 0.0 & contact_scaling <= 1.0),
     "Error: contact matrix must have a maximum real eigenvalue of 1.0" =
       (
         abs(

--- a/R/r0_conversions.R
+++ b/R/r0_conversions.R
@@ -268,6 +268,11 @@ r_eff <- function(r0,
       (
         all(abs(rowSums(p_susceptibility) - 1) < 1e-6)
       ),
+    "Error: contact_scaling must be a number or length of demography vector" =
+      is.numeric(contact_scaling) && (length(contact_scaling) == 1 ||
+        length(contact_scaling) == length(demography_vector)),
+    "Error: contact_scaling must be in the range 0.0 -- 1.0" =
+      all(contact_scaling >= 0.0 & contact_scaling <= 1.0),
     "Error: contact matrix must have a maximum real eigenvalue of 1.0" =
       (
         abs(max(Re(eigen(

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -12,6 +12,7 @@ articles:
   - varying_susceptibility
   - uncertainty_params
   - demographic_turnover
+  - r_eff_reckoner
 - title: Modelling guides and background
   navbar: Modelling guides and background
   contents:

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -54,6 +54,7 @@ io
 mathbf
 mathrm
 md
+olds
 overbrace
 packagename
 packagetemplate

--- a/man/final_size.Rd
+++ b/man/final_size.Rd
@@ -10,6 +10,7 @@ final_size(
   demography_vector = 1,
   susceptibility = matrix(1),
   p_susceptibility = matrix(1),
+  contact_scaling = 1,
   solver = c("iterative", "newton"),
   control = list()
 )
@@ -40,6 +41,11 @@ Each row represents the overall distribution of individuals in demographic
 group \eqn{i} across risk groups, and each row \emph{must sum to 1.0}.
 Defaults to the singleton matrix \eqn{[1]}, representing a population where
 all individuals are fully susceptible.}
+
+\item{contact_scaling}{For \code{r_eff()}, either a single number or a numeric
+vector of the same length as \code{demography_vector}, giving the proportional
+scaling of contacts of each demographic group. Values must be in the range
+\eqn{[0, 1]}. Defaults to 1.0 for no scaling.}
 
 \item{solver}{Which solver to use. Options are "iterative" (default) or
 "newton", for the iterative solver, or the Newton solver, respectively.
@@ -141,6 +147,20 @@ final_size(
   demography_vector = demography_vector,
   susceptibility = susceptibility,
   p_susceptibility = p_susceptibility
+)
+
+## Examining the effect of contact reductions
+# In this example, contacts are reduced by 5\%
+final_size(r0, contact_scaling = 0.95)
+
+# Demography-sepcific reduction in contacts
+final_size(
+  r0 = r0,
+  contact_matrix = contact_matrix,
+  demography_vector = demography_vector,
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility,
+  contact_scaling = c(0.95, 0.9, 0.85)
 )
 
 ## Using manually specified solver settings for the iterative solver

--- a/man/r0_conversions.Rd
+++ b/man/r0_conversions.Rd
@@ -25,7 +25,14 @@ r0_to_lambda(
   infectious_period = 1.8
 )
 
-r_eff(r0, contact_matrix, demography_vector, susceptibility, p_susceptibility)
+r_eff(
+  r0,
+  contact_matrix,
+  demography_vector,
+  susceptibility,
+  p_susceptibility,
+  contact_scaling = 1
+)
 }
 \arguments{
 \item{lambda}{The transmission rate of the disease, also called the 'force of
@@ -50,6 +57,11 @@ group \eqn{i} across risk groups, and each row \emph{must sum to 1.0}.}
 Default value is 1.8 days.}
 
 \item{r0}{The basic reproductive number \eqn{R_0} of the infection.}
+
+\item{contact_scaling}{For \code{r_eff()}, either a single number or a numeric
+vector of the same length as \code{demography_vector}, giving the proportional
+scaling of contacts of each demographic group. Values must be in the range
+\eqn{[0, 1]}. Defaults to 1.0 for no scaling.}
 }
 \value{
 Returns a single number for the calculated value.
@@ -125,6 +137,16 @@ r_eff(
   demography_vector = demography_vector,
   susceptibility = susceptibility,
   p_susceptibility = p_susceptibility
+)
+
+# With a 5\% reduction in contacts
+r_eff(
+  r0 = r0,
+  contact_matrix = contact_matrix,
+  demography_vector = demography_vector,
+  susceptibility = susceptibility,
+  p_susceptibility = p_susceptibility,
+  contact_scaling = 0.95
 )
 
 #### Transmission rate to R0 ####

--- a/tests/testthat/test-contact_scaling.R
+++ b/tests/testthat/test-contact_scaling.R
@@ -1,0 +1,87 @@
+test_that("Contact scaling works in `final_size()`", {
+  r0 <- 1.5
+
+  # simple case
+  expect_no_condition(
+    final_size(r0, contact_scaling = 0.5)
+  )
+
+  scaling <- 0.95
+  fs <- final_size(r0)
+  fs_scaled <- final_size(r0, contact_scaling = scaling)
+
+  expect_lt(
+    fs_scaled$p_infected, fs$p_infected
+  )
+  expect_false(
+    identical(fs_scaled$p_infected, fs$p_infected * scaling)
+  )
+
+  expect_error(
+    final_size(r0, contact_scaling = -1.0)
+  )
+  expect_error(
+    final_size(r0, contact_scaling = 1.1)
+  )
+  expect_error(
+    final_size(r0, contact_scaling = c(1, 1))
+  )
+
+  # complex case
+  demography <- rep(1000, 4)
+  cm <- (matrix(1, 4, 4) / 4) / demography
+  p_susc <- matrix(1, 4, 1)
+  susc <- matrix(1, 4, 1)
+  scaling <- rep(0.95, 4)
+
+  expect_no_condition(
+    final_size(r0, cm, demography, susc, p_susc, scaling)
+  )
+
+  expect_true(
+    all(final_size(r0, cm, demography, susc, p_susc, scaling)$p_infected <
+      final_size(r0, cm, demography, susc, p_susc)$p_infected)
+  )
+})
+
+test_that("Contact scaling works in `r_eff()`", {
+  r0 <- 1.5
+
+  # simple case
+  expect_no_condition(
+    r_eff(r0, matrix(1), 1, matrix(1), matrix(1), contact_scaling = 0.5)
+  )
+
+  scaling <- 0.95
+  reff_scaled <- r_eff(r0, matrix(1), 1, matrix(1), matrix(1), scaling)
+
+  expect_lt(
+    reff_scaled, r0
+  )
+
+  expect_error(
+    r_eff(r0, matrix(1), 1, matrix(1), matrix(1), contact_scaling = -1.0)
+  )
+  expect_error(
+    r_eff(r0, matrix(1), 1, matrix(1), matrix(1), contact_scaling = 1.1)
+  )
+  expect_error(
+    r_eff(r0, matrix(1), 1, matrix(1), matrix(1), contact_scaling = c(1, 1))
+  )
+
+  # complex case
+  demography <- rep(1000, 4)
+  cm <- (matrix(1, 4, 4) / 4) / demography
+  p_susc <- matrix(1, 4, 1)
+  susc <- matrix(1, 4, 1)
+  scaling <- rep(0.95, 4)
+
+  expect_no_condition(
+    final_size(r0, cm, demography, susc, p_susc, scaling)
+  )
+
+  expect_true(
+    all(final_size(r0, cm, demography, susc, p_susc, scaling)$p_infected <
+      final_size(r0, cm, demography, susc, p_susc)$p_infected)
+  )
+})

--- a/vignettes/r_eff_reckoner.Rmd
+++ b/vignettes/r_eff_reckoner.Rmd
@@ -1,0 +1,198 @@
+---
+title: "Ready reckoner for R<sub>eff</sub>"
+output:
+  bookdown::html_vignette2:
+    fig_caption: yes
+    code_folding: show
+vignette: >
+  %\VignetteIndexEntry{Ready reckoner for Reff}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(finalsize)
+library(dplyr)
+library(tidyr)
+library(ggplot2)
+```
+
+The _finalsize_ package provides a quick way to calculate the effective reproduction number using the `r_eff()` function.
+This vignette shows how to use the `contact_scaling` argument to calculate the effective reproduction number for different scenarios.
+
+## Setup
+
+We access social contacts data for the U.K. for six age groups: three school-age groups of 0 -- 4, 5 -- 11, 12 -- 17, and three adult groups of 18 -- 39, 40 -- 65, and 65+.
+
+Age groups are chosen to model the effect of school closures and resulting reduction in social contacts for school-age groups on $R_\text{eff}$.
+
+We assume all age groups are completely susceptible to infection.
+
+```{r}
+polymod <- socialmixr::polymod
+contact_data <- socialmixr::contact_matrix(
+  polymod,
+  countries = "United Kingdom",
+  age.limits = c(0, 5, 12, 17, 40, 65),
+  symmetric = TRUE
+)
+
+# get the contact matrix and demography data
+contact_matrix <- t(contact_data$matrix)
+demography_vector <- contact_data$demography$population
+
+# scale the contact matrix so the largest eigenvalue is 1.0
+# this is to ensure that the overall epidemic dynamics correctly reflect
+# the assumed value of R0
+contact_matrix <- contact_matrix / max(Re(eigen(contact_matrix)$values))
+
+# divide each row of the contact matrix by the corresponding demography
+# this reflects the assumption that each individual in group {j} make contacts
+# at random with individuals in group {i}
+contact_matrix <- contact_matrix / demography_vector
+
+n_demo_grps <- length(demography_vector)
+
+# all individuals are equally and highly susceptible
+n_susc_groups <- 1L
+susc_guess <- 1.0
+
+susc_uniform <- matrix(
+  data = susc_guess,
+  nrow = n_demo_grps,
+  ncol = n_susc_groups
+)
+
+p_susc_uniform <- matrix(
+  data = 1.0,
+  nrow = n_demo_grps,
+  ncol = n_susc_groups
+)
+```
+
+## Scenarios of contact reduction
+
+We model four scenarios of school closures, and multiple levels of scaling of adult social contacts.
+
+Note that all values and assumptions are solely illustrative.
+
+```{r}
+# create an age-specific scaling vector for re-use
+scaling_factor <- rep(1, n_demo_grps)
+
+# adult age groups
+i_adult <- c(4, 5, 6)
+
+n_school_age <- 3L
+```
+
+We assume that:
+
+1. Full school closures reduce all school-age groups' contacts by 80%;
+
+2. 0-5 year olds' contacts are not affected in any other scenario;
+
+3. When 50% of 5-11 year olds are at school, contacts are reduced by 40%;
+
+4. 12-17 year olds have an 80% reduction in contacts except when all schools are open;
+
+5. Adults' social contacts are not affected by school closures.
+
+```{r}
+# create scenarios of school closures
+scenarios <- factor(
+  c("schools_closed", "ps_half_open", "ps_open", "schools_open"),
+  levels = c("schools_closed", "ps_half_open", "ps_open", "schools_open")
+)
+
+scenario_names <- c(
+  "Schools closed", "Primary schools 50% open",
+  "Primary schools open", "Schools open"
+)
+
+school_scaling <- list(
+  schools_closed = rep(0.2, n_school_age), # full closure cuts contacts by 80%
+  ps_half_open = c(1.0, 0.6, 0.2), # 50% 5-11 yr olds cuts contacts by 40%
+  ps_open = c(1.0, 1.0, 0.2),
+  schools_open = rep(1.0, n_school_age)
+)
+
+# make a tibble and cross-join with scaling values
+scenarios <- tibble(
+  scenarios,
+  school_scaling
+)
+
+scaling_values <- seq(0.0, 1.0, 0.1) # adult scaling from 0% - 100%
+
+scenarios <- crossing(
+  scenarios, scaling_values
+)
+```
+
+```{r}
+# combine adult and school-age contact scaling values for 4 * 11 scenarios
+scenarios <- mutate(
+  scenarios,
+  contact_scaling = Map(
+    school_scaling, scaling_values,
+    f = function(x, y) {
+      scaling_factor <- c(x, rep(y, 3)) # all adult contacts scaled the same
+    }
+  )
+)
+
+# calculate R_eff assuming R0 = 3.0
+r0 <- 3.0
+
+scenarios <- mutate(
+  scenarios,
+  r_eff = vapply(
+    contact_scaling,
+    function(x) {
+      r_eff(
+        r0,
+        contact_matrix, demography_vector, susc_uniform,
+        p_susc_uniform,
+        contact_scaling = x
+      )
+    }, numeric(1)
+  )
+)
+```
+
+We plot the $R_\text{eff}$ values.
+
+```{r class.source = 'fold-hide'}
+ggplot(scenarios) +
+  geom_line(
+    aes(scaling_values, r_eff, col = scenarios)
+  ) +
+  scale_color_brewer(
+    palette = "Dark2",
+    labels = scenario_names
+  ) +
+  scale_x_continuous(
+    labels = scales::percent
+  ) +
+  scale_y_continuous(
+    breaks = seq(0.5, 3, 0.5)
+  ) +
+  theme_bw() +
+  labs(
+    x = "% of adult contacts",
+    y = "R<sub>eff</sub>",
+    colour = NULL
+  ) +
+  theme(
+    axis.title.y.left = ggtext::element_markdown(),
+    legend.position = "top"
+  )
+```


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [x] A new item has been added to `NEWS.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR is WIP on #220 since I had some time and this functionality would be generally useful. cc-ing @adamkucharski  and @ellen-is for feedback.

1. Added a `contact_scaling` argument to `final_size()` and `r_eff()` that allows uniform or group-wise scaling of social contacts; defaults to 1.0 for no scaling. It would be worth checking that the contacts scaling is done correctly, and that overall this is what the issue requires.
2. Added tests and documentation for the new argument;
3. Added a new vignette aiming to make plot similar to https://github.com/ellen-is/reckoners. The vignette figures don't include any uncertainty as I haven't added any of the stochasticity around contacts. I've made a bunch of fairly naive assumptions around how a policy label translates to age-specific contact scaling, feel free to edit these as needed.

* **What is the current behavior?** (You can also link to an open issue here)

See discussion under issue #220 for feature request.

* **What is the new behavior (if this is a feature change)?**

`final_size()` and `r_eff()` scale the `contact_matrix` argument by the `contact_scaling` argument to allow simulation of the effect of reducing social contacts overall or in a group-specific way.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Unlikely.

* **Other information**:

I expect the benchmarking workflow will fail; see #223.
